### PR TITLE
requirements.txt: remove dependency on ipython

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,3 @@ flask
 requests
 pytest
 psutil
-ipython


### PR DESCRIPTION
This is not used anywhere, but having it in this file, makes it a dependency, when installing it.