### PR TITLE
makes active command return all active tabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ positional arguments:
                         command to obtain tab IDs (first column)
     activate            activate given tab ID. Tab ID should be in the following
                         format: "<prefix>.<window_id>.<tab_id>"
-    active              display active tab for each client/window in the following
+    active              display active tabs for each client/window in the following
                         format: "<prefix>.<window_id>.<tab_id>"
     search              Search across your indexed tabs using sqlite fts5 plugin.
     index               Index the text from browser's tabs. Text is put into sqlite

--- a/brotab/api.py
+++ b/brotab/api.py
@@ -96,8 +96,8 @@ class SingleMediatorAPI(object):
         self._get('/activate_tab/%s' % tab_id)
         #self._get('/activate_tab/%s' % strWindowTab)
 
-    def get_active_tab(self, args) -> str:
-        return [self.prefix_tab(tab) for tab in self._get('/get_active_tab').split(',')]
+    def get_active_tabs(self, args) -> [str]:
+        return [self.prefix_tab(tab) for tab in self._get('/get_active_tabs').split(',')]
 
     # def new_tab(self, prefix, search_query):
     #     if prefix != self._prefix:
@@ -233,8 +233,8 @@ class MultipleMediatorsAPI(object):
             api.activate_tab(args)
 
     def get_active_tabs(self, args):
-        return [api.get_active_tab(args) for api in self._apis]
-        #return ['%s\t%s' % (api.get_active_tab(args), api) for api in self._apis]
+        return [api.get_active_tabs(args) for api in self._apis]
+        #return ['%s\t%s' % (api.get_active_tabs(args), api) for api in self._apis]
 
     # def new_tab(self, args):
     #     if len(args) <= 1:

--- a/brotab/api.py
+++ b/brotab/api.py
@@ -97,7 +97,7 @@ class SingleMediatorAPI(object):
         #self._get('/activate_tab/%s' % strWindowTab)
 
     def get_active_tab(self, args) -> str:
-        return self.prefix_tab(self._get('/get_active_tab'))
+        return [self.prefix_tab(tab) for tab in self._get('/get_active_tab').split(',')]
 
     # def new_tab(self, prefix, search_query):
     #     if prefix != self._prefix:

--- a/brotab/extension/background.js
+++ b/brotab/extension/background.js
@@ -253,8 +253,7 @@ function activateTab(tab_id) {
 
 function getActiveTab() {
   browserTabs.getActive(tabs => {
-      let tab = tabs[0];
-      var result = tab.windowId + "." + tab.id;
+      var result = tabs.map(tab => tab.windowId + "." + tab.id).toString()
       console.log(`Active tab: ${result}`);
       port.postMessage(result);
   });

--- a/brotab/extension/background.js
+++ b/brotab/extension/background.js
@@ -251,10 +251,10 @@ function activateTab(tab_id) {
   browserTabs.activate(tab_id);
 }
 
-function getActiveTab() {
+function getActiveTabs() {
   browserTabs.getActive(tabs => {
       var result = tabs.map(tab => tab.windowId + "." + tab.id).toString()
-      console.log(`Active tab: ${result}`);
+      console.log(`Active tabs: ${result}`);
       port.postMessage(result);
   });
 }
@@ -289,7 +289,7 @@ function getWordsFromTabs(tabs) {
 
 function getWords(tab_id) {
   if (tab_id == null) {
-    console.log(`Getting words for active tab`);
+    console.log(`Getting words for active tabs`);
     browserTabs.getActive(getWordsFromTabs);
   } else {
     console.log(`Getting words, running a script`);
@@ -398,9 +398,9 @@ port.onMessage.addListener((command) => {
     activateTab(command['tab_id']);
   }
 
-  else if (command['name'] == 'get_active_tab') {
-    console.log('Getting active tab');
-    getActiveTab();
+  else if (command['name'] == 'get_active_tabs') {
+    console.log('Getting active tabs');
+    getActiveTabs();
   }
 
   else if (command['name'] == 'get_words') {

--- a/brotab/extension/chrome/background.js
+++ b/brotab/extension/chrome/background.js
@@ -253,8 +253,7 @@ function activateTab(tab_id) {
 
 function getActiveTab() {
   browserTabs.getActive(tabs => {
-      let tab = tabs[0];
-      var result = tab.windowId + "." + tab.id;
+      var result = tabs.map(tab => tab.windowId + "." + tab.id).toString()
       console.log(`Active tab: ${result}`);
       port.postMessage(result);
   });

--- a/brotab/extension/chrome/background.js
+++ b/brotab/extension/chrome/background.js
@@ -251,10 +251,10 @@ function activateTab(tab_id) {
   browserTabs.activate(tab_id);
 }
 
-function getActiveTab() {
+function getActiveTabs() {
   browserTabs.getActive(tabs => {
       var result = tabs.map(tab => tab.windowId + "." + tab.id).toString()
-      console.log(`Active tab: ${result}`);
+      console.log(`Active tabs: ${result}`);
       port.postMessage(result);
   });
 }
@@ -289,7 +289,7 @@ function getWordsFromTabs(tabs) {
 
 function getWords(tab_id) {
   if (tab_id == null) {
-    console.log(`Getting words for active tab`);
+    console.log(`Getting words for active tabs`);
     browserTabs.getActive(getWordsFromTabs);
   } else {
     console.log(`Getting words, running a script`);
@@ -398,9 +398,9 @@ port.onMessage.addListener((command) => {
     activateTab(command['tab_id']);
   }
 
-  else if (command['name'] == 'get_active_tab') {
-    console.log('Getting active tab');
-    getActiveTab();
+  else if (command['name'] == 'get_active_tabs') {
+    console.log('Getting active tabs');
+    getActiveTabs();
   }
 
   else if (command['name'] == 'get_words') {

--- a/brotab/extension/firefox/background.js
+++ b/brotab/extension/firefox/background.js
@@ -253,8 +253,7 @@ function activateTab(tab_id) {
 
 function getActiveTab() {
   browserTabs.getActive(tabs => {
-      let tab = tabs[0];
-      var result = tab.windowId + "." + tab.id;
+      var result = tabs.map(tab => tab.windowId + "." + tab.id).toString()
       console.log(`Active tab: ${result}`);
       port.postMessage(result);
   });

--- a/brotab/extension/firefox/background.js
+++ b/brotab/extension/firefox/background.js
@@ -251,10 +251,10 @@ function activateTab(tab_id) {
   browserTabs.activate(tab_id);
 }
 
-function getActiveTab() {
+function getActiveTabs() {
   browserTabs.getActive(tabs => {
       var result = tabs.map(tab => tab.windowId + "." + tab.id).toString()
-      console.log(`Active tab: ${result}`);
+      console.log(`Active tabs: ${result}`);
       port.postMessage(result);
   });
 }
@@ -289,7 +289,7 @@ function getWordsFromTabs(tabs) {
 
 function getWords(tab_id) {
   if (tab_id == null) {
-    console.log(`Getting words for active tab`);
+    console.log(`Getting words for active tabs`);
     browserTabs.getActive(getWordsFromTabs);
   } else {
     console.log(`Getting words, running a script`);
@@ -398,9 +398,9 @@ port.onMessage.addListener((command) => {
     activateTab(command['tab_id']);
   }
 
-  else if (command['name'] == 'get_active_tab') {
-    console.log('Getting active tab');
-    getActiveTab();
+  else if (command['name'] == 'get_active_tabs') {
+    console.log('Getting active tabs');
+    getActiveTabs();
   }
 
   else if (command['name'] == 'get_words') {

--- a/brotab/main.py
+++ b/brotab/main.py
@@ -145,14 +145,14 @@ def activate_tab(args):
     api.activate_tab(args.tab_id)
 
 
-def show_active_tab(args):
+def show_active_tabs(args):
     logger.info('Showing active tabs: %s', args)
     #api = MultipleMediatorsAPI([SingleMediatorAPI('f')])
     apis = create_clients()
     # api = MultipleMediatorsAPI(create_clients())
     # tabs = api.get_active_tabs(args)
     for api in apis:
-        tabs = api.get_active_tab(args)
+        tabs = api.get_active_tabs(args)
         for tab in tabs:
             print('%s\t%s' % (tab, api))
     # print('\n'.join(tabs))
@@ -376,7 +376,7 @@ def parse_args(args):
         activate given tab ID. Tab ID should be in the following format:
         "<prefix>.<window_id>.<tab_id>"
         ''')
-    parser_activate_tab.set_defaults(func=activate_tab)
+    parser_activate_tab.set_defaults(func=activate_tabs)
     parser_activate_tab.add_argument('tab_id', type=str, nargs=1,
                                      help='Tab ID to activate')
 

--- a/brotab/main.py
+++ b/brotab/main.py
@@ -152,8 +152,9 @@ def show_active_tab(args):
     # api = MultipleMediatorsAPI(create_clients())
     # tabs = api.get_active_tabs(args)
     for api in apis:
-        line = '%s\t%s' % (api.get_active_tab(args), api)
-        print(line)
+        tabs = api.get_active_tab(args)
+        for tab in tabs:
+            print('%s\t%s' % (tab, api))
     # print('\n'.join(tabs))
     # api.activate_tab(args.tab_id)
 

--- a/brotab/mediator/brotab_mediator.py
+++ b/brotab/mediator/brotab_mediator.py
@@ -121,9 +121,9 @@ class BrowserRemoteAPI:
         command = {'name': 'activate_tab', 'tab_id': tab_id}
         self._transport.send(command)
 
-    def get_active_tab(self) -> str:
-        logger.info('getting active tab')
-        command = {'name': 'get_active_tab'}
+    def get_active_tabs(self) -> str:
+        logger.info('getting active tabs')
+        command = {'name': 'get_active_tabs'}
         self._transport.send(command)
         return self._transport.recv()
 
@@ -199,9 +199,9 @@ def activate_tab(tab_id):
     return 'OK'
 
 
-@app.route('/get_active_tab')
-def get_active_tab():
-    return browser.get_active_tab()
+@app.route('/get_active_tabs')
+def get_active_tabs():
+    return browser.get_active_tabs()
 
 
 @app.route('/get_words')
@@ -247,7 +247,7 @@ def root_handler():
 #    - /open_urls
 #    - /new_tab (google search)
 #    - /get_tab_text
-#    - /get_active_tab_text
+#    - /get_active_tabs_text
 #
 # TODO: fix bug when the number of tabs > 1100
 # TODO: read stdin continuously in a separate thraed,


### PR DESCRIPTION
The active command returned only the first tab in the `chrome.tabs.query` response for each client rather than all active tabs for each client i.e. the active tabs for each window of each client. This commit changes the behaviour to the latter case.