### PR TITLE
implements query command which directly exposes chrome.tabs.query

### DIFF
--- a/brotab/api.py
+++ b/brotab/api.py
@@ -2,11 +2,13 @@ import io
 import sys
 import socket
 import logging
+import json
 from traceback import print_exc
 from urllib.error import URLError, HTTPError
 from urllib.request import Request, urlopen
 from urllib.parse import quote_plus
 from functools import partial
+from collections.abc import Mapping
 
 from brotab.inout import edit_tabs_in_editor
 from brotab.inout import MultiPartForm
@@ -107,6 +109,13 @@ class SingleMediatorAPI(object):
     #     self._get('/new_tab/%s' % search_query)
 
     def query_tabs(self, args):
+        try:
+            if not isinstance(json.loads(json.loads(args)), Mapping):
+                raise json.JSONDecodeError("json has attributes unsupported by brotab.", "", 0)
+        except json.JSONDecodeError as e:
+            print("Cannot decode JSON: %s: %s" % (__name__, e), file=sys.stderr)
+            return []
+
         result = self._get('/query_tabs/%s' % encode_query(args))
         lines = result.splitlines()[:MAX_NUMBER_OF_TABS]
         return self.prefix_tabs(lines)

--- a/brotab/api.py
+++ b/brotab/api.py
@@ -110,18 +110,16 @@ class SingleMediatorAPI(object):
 
     def query_tabs(self, args):
         query = args
-        try:
-            if not isinstance(query, Mapping):
-                _query = json.loads(query)
-            if not isinstance(_query, Mapping):
-                _query = json.loads(_query)
-            if not isinstance(_query, Mapping):
-                raise json.JSONDecodeError("json has attributes unsupported by brotab.", "", 0)
-        except json.JSONDecodeError as e:
-            print("Cannot decode JSON: %s: %s" % (__name__, e), file=sys.stderr)
-            return []
+        if isinstance(query, str):
+            try:
+                query = json.loads(query)
+                if not isinstance(query, Mapping):
+                    raise json.JSONDecodeError("json has attributes unsupported by brotab.", "", 0)
+            except json.JSONDecodeError as e:
+                print("Cannot decode JSON: %s: %s" % (__name__, e), file=sys.stderr)
+                return []
 
-        result = self._get('/query_tabs/%s' % encode_query(query))
+        result = self._get('/query_tabs/%s' % encode_query(json.dumps(query)))
         lines = result.splitlines()[:MAX_NUMBER_OF_TABS]
         return self.prefix_tabs(lines)
 

--- a/brotab/api.py
+++ b/brotab/api.py
@@ -109,14 +109,19 @@ class SingleMediatorAPI(object):
     #     self._get('/new_tab/%s' % search_query)
 
     def query_tabs(self, args):
+        query = args
         try:
-            if not isinstance(json.loads(json.loads(args)), Mapping):
+            if not isinstance(query, Mapping):
+                _query = json.loads(query)
+            if not isinstance(_query, Mapping):
+                _query = json.loads(_query)
+            if not isinstance(_query, Mapping):
                 raise json.JSONDecodeError("json has attributes unsupported by brotab.", "", 0)
         except json.JSONDecodeError as e:
             print("Cannot decode JSON: %s: %s" % (__name__, e), file=sys.stderr)
             return []
 
-        result = self._get('/query_tabs/%s' % encode_query(args))
+        result = self._get('/query_tabs/%s' % encode_query(query))
         lines = result.splitlines()[:MAX_NUMBER_OF_TABS]
         return self.prefix_tabs(lines)
 

--- a/brotab/extension/background.js
+++ b/brotab/extension/background.js
@@ -229,11 +229,12 @@ function queryTabs(query_info) {
   try {
     let query = atob(query_info)
     query = JSON.parse(query)
-    if (typeof query == 'string')
-      query = JSON.parse(query)
-    integerKeys = {'windowId': null, 'index': null};
-    booleanKeys = {'active': null, 'pinned': null, 'audible': null, 'muted': null, 'highlighted': null,
-      'discarded': null, 'autoDiscardable': null, 'currentWindow': null, 'lastFocusedWindow': null};
+    
+    integerKeys = { 'windowId': null, 'index': null };
+    booleanKeys = { 'active': null, 'pinned': null, 'audible': null,
+      'muted': null, 'highlighted': null, 'discarded': null,
+      'autoDiscardable': null, 'currentWindow': null, 'lastFocusedWindow': null };
+    
     query = Object.entries(query).reduce((o, [k,v]) => {
       if (booleanKeys.hasOwnProperty(k) && typeof v != 'boolean') {
         if (v.toLowerCase() == 'true')
@@ -249,6 +250,7 @@ function queryTabs(query_info) {
         o[k] = v;
       return o;
     }, {})
+
     browserTabs.query(query, queryTabsOnSuccess, queryTabsOnFailure);
   }
   catch(error) {

--- a/brotab/extension/chrome/background.js
+++ b/brotab/extension/chrome/background.js
@@ -229,11 +229,11 @@ function queryTabs(query_info) {
   try {
     let query = atob(query_info)
     query = JSON.parse(query)
-    if (typeof query == 'string')
-      query = JSON.parse(query)
+    
     integerKeys = {'windowId': null, 'index': null};
     booleanKeys = {'active': null, 'pinned': null, 'audible': null, 'muted': null, 'highlighted': null,
       'discarded': null, 'autoDiscardable': null, 'currentWindow': null, 'lastFocusedWindow': null};
+    
     query = Object.entries(query).reduce((o, [k,v]) => {
       if (booleanKeys.hasOwnProperty(k) && typeof v != 'boolean') {
         if (v.toLowerCase() == 'true')
@@ -249,6 +249,7 @@ function queryTabs(query_info) {
         o[k] = v;
       return o;
     }, {})
+    
     browserTabs.query(query, queryTabsOnSuccess, queryTabsOnFailure);
   }
   catch(error) {

--- a/brotab/extension/firefox/background.js
+++ b/brotab/extension/firefox/background.js
@@ -229,11 +229,11 @@ function queryTabs(query_info) {
   try {
     let query = atob(query_info)
     query = JSON.parse(query)
-    if (typeof query == 'string')
-      query = JSON.parse(query)
+    
     integerKeys = {'windowId': null, 'index': null};
     booleanKeys = {'active': null, 'pinned': null, 'audible': null, 'muted': null, 'highlighted': null,
       'discarded': null, 'autoDiscardable': null, 'currentWindow': null, 'lastFocusedWindow': null};
+    
     query = Object.entries(query).reduce((o, [k,v]) => {
       if (booleanKeys.hasOwnProperty(k) && typeof v != 'boolean') {
         if (v.toLowerCase() == 'true')
@@ -249,6 +249,7 @@ function queryTabs(query_info) {
         o[k] = v;
       return o;
     }, {})
+    
     browserTabs.query(query, queryTabsOnSuccess, queryTabsOnFailure);
   }
   catch(error) {

--- a/brotab/main.py
+++ b/brotab/main.py
@@ -57,7 +57,6 @@ from argparse import ArgumentParser
 from functools import partial
 from itertools import groupby
 from urllib.parse import quote_plus, quote
-from json import dumps as json_dumps
 
 from brotab.inout import is_port_accepting_connections
 from brotab.inout import read_stdin
@@ -177,7 +176,6 @@ def query_tabs(args):
         queryInfo = d['info']
     else:
         queryInfo = {k: v for k, v in d.items() if v is not None and k not in ['func', 'info']}
-    queryInfo = json_dumps(queryInfo)
     api = MultipleMediatorsAPI(create_clients())
     for tab in api.query_tabs(queryInfo):
         print(tab)

--- a/brotab/mediator/brotab_mediator.py
+++ b/brotab/mediator/brotab_mediator.py
@@ -92,6 +92,12 @@ class BrowserRemoteAPI:
         self._transport.send(command)
         return self._transport.recv()
 
+    def query_tabs(self, query_info: str):
+        logger.info('query info: %s', query_info)
+        command = {'name': 'query_tabs', 'query_info': query_info}
+        self._transport.send(command)
+        return self._transport.recv()
+
     def move_tabs(self, move_triplets: str):
         """
         :param move_triplets: Comma-separated list of:
@@ -195,6 +201,12 @@ def shutdown():
 @app.route('/list_tabs')
 def list_tabs():
     tabs = browser.list_tabs()
+    return '\n'.join(tabs)
+
+
+@app.route('/query_tabs/<query_info>')
+def query_tabs(query_info):
+    tabs = browser.query_tabs(query_info)
     return '\n'.join(tabs)
 
 


### PR DESCRIPTION
This exposes the `chrome.tabs.query` method through a new brotab command `query`. `chrome.tabs.query({active: True})` was already exposed via the brotab command  `active`, and `chrome.tabs.query({})`, via `list`. I was particularly interested in exposing the `audible`, `title`, and `url` parameters. The other parameters are not of immediate interest to me, but it seems better to implement a single function that handles them all rather than a seperate functions for each parameter. This way they can be combined in one call.

This also allows the `list` and `active` commands to be rewritten as basically aliases to `query` with specific parameters. In fact, `query` without any arguments produces the same output as `list`. Other more useful parameters can similarly be aliased.

The object argument to `chrome.tabs.query` accepts many optional boolean arguments. These have been implented for each argument `name` in the form `[-+]<name>`, where the `+` prefix denotes `True` and the `-` prefix denotes `False`. This makes for (slightly) more concise commands when compared to something like `-foo True -bar False`. Non-boolean parameters assume the traditional `-<name>` format, which, in relation to the `+/-` syntax, may be confusing to some. It also doubles the number of parameters for that subset of the command. Is this acceptable? The entire `queryInfo` object can be passed as a string literal through the `info` argument.

The `windowId` parameter may be completely useless. I have not checked if brotab performs any conversion or keeps any intermediate table.

The name `query` is consistent with the `chrome.tabs` api, but query is an argument of `search` and possibly other brotab commands. It is not really an issue for usage, but might be within source.

The whole query to the js portion is base 64 encoded via a brotab utility function because I had difficulty preventing mangling with quoting and escaping. This is probably good for long arrays of urls, but overkill for one or two booleans. A check for the presences of certain parameters can pivot appraches, but I don't know if thats necessary.