### PR TITLE
Several Changes : 

### DIFF
--- a/brotab/api.py
+++ b/brotab/api.py
@@ -99,6 +99,17 @@ class SingleMediatorAPI(object):
         self._get('/activate_tab/%s' % tab_id)
         #self._get('/activate_tab/%s' % strWindowTab)
 
+    def activateFocus_tab(self, args):
+        # args = self.filter_tabs(args)
+        if len(args) == 0:
+            return
+
+        strWindowTab = args[0]
+        prefix, window_id, tab_id = strWindowTab.split('.')
+        self._get('/activateFocus_tab/%s' % tab_id)
+        #self._get('/activate_tab/%s' % strWindowTab)
+        
+        
     def get_active_tabs(self, args) -> [str]:
         return [self.prefix_tab(tab) for tab in self._get('/get_active_tabs').split(',')]
 
@@ -197,7 +208,7 @@ class SingleMediatorAPI(object):
                 'SingleMediatorAPI: get_words: %s, match_regex: %s, join_with: %s',
                 tab_id, match_regex, join_with)
             words |= set(self._get(
-                '/get_words/%s?match_regex=%s&join_with=%s' % (tab_id, match_regex, join_with)
+                '/get_words/%s/?match_regex=%s&join_with=%s' % (tab_id, match_regex, join_with)
             ).splitlines())
 
         if not tab_ids:
@@ -278,6 +289,14 @@ class MultipleMediatorsAPI(object):
         for api in self._apis:
             api.activate_tab(args)
 
+    def activateFocus_tab(self, args):
+        if len(args) == 0:
+            print('Usage: brotab_client.py activateFocus_tab <#tab>')
+            return 2
+
+        for api in self._apis:
+            api.activateFocus_tab(args)
+            
     def get_active_tabs(self, args):
         return [api.get_active_tabs(args) for api in self._apis]
         #return ['%s\t%s' % (api.get_active_tabs(args), api) for api in self._apis]

--- a/brotab/inout.py
+++ b/brotab/inout.py
@@ -38,7 +38,7 @@ def edit_tabs_in_editor(tabs_before):
         try:
             #check_call([os.environ.get('EDITOR', 'notepad'), file_name]) #            check_call([os.environ.get('EDITOR', 'nvim'), file_.name])
             Editor = 'notepad' if (platform.system()=='Windows') else 'nvim'
-            check_call([os.environ.get('EDITOR', Editor), file_.name])
+            check_call([os.environ.get('EDITOR', Editor), file_name])
             tabs_after = load_tabs_from_file(file_name)
             return tabs_after
         except CalledProcessError:

--- a/brotab/inout.py
+++ b/brotab/inout.py
@@ -9,34 +9,40 @@ from tempfile import NamedTemporaryFile
 from subprocess import check_call, CalledProcessError
 
 
-def is_port_accepting_connections(port):
+def is_port_accepting_connections(port, host='127.0.0.1'):
     s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     s.settimeout(0.100)
-    result = s.connect_ex(('127.0.0.1', port))
+    result = s.connect_ex((host, port))
     s.close()
     return result == 0
 
 
 def save_tabs_to_file(tabs, filename):
-    with open(filename, 'w') as file_:
+    with open(filename, 'w', encoding='utf-8') as file_:
         file_.write('\n'.join(tabs))
 
 
 def load_tabs_from_file(filename):
-    with open(filename) as file_:
-        return [line.strip() for line in file_.readlines()]
+    with open(filename, encoding='utf-8') as file_:
+        Lines = [line.strip() for line in file_.readlines()]
+    if os.path.exists(filename):
+        os.remove(filename)
+    return Lines
 
 
 def edit_tabs_in_editor(tabs_before):
     with NamedTemporaryFile() as file_:
-        save_tabs_to_file(tabs_before, file_.name)
+        file_name=file_.name
+        file_.close()
+        save_tabs_to_file(tabs_before, file_name)
         try:
-            check_call([os.environ.get('EDITOR', 'nvim'), file_.name])
-            tabs_after = load_tabs_from_file(file_.name)
+            #check_call([os.environ.get('EDITOR', 'notepad'), file_name]) #            check_call([os.environ.get('EDITOR', 'nvim'), file_.name])
+            Editor = 'notepad' if (platform.system()=='Windows') else 'nvim'
+            check_call([os.environ.get('EDITOR', Editor), file_.name])
+            tabs_after = load_tabs_from_file(file_name)
             return tabs_after
         except CalledProcessError:
             return None
-
 
 def read_stdin():
     if select.select([sys.stdin, ], [], [], 1.0)[0]:


### PR DESCRIPTION
Mediator : Fix to work on windows.
Mediator : Checks the ports to look for the first not open.
Fix words comand : avoid an http redirect that generates an error.
Fix move command : Notepad for windows as editor, fix cannot open a temporary open file, add encoding='utf-8'  to void char problems.
Add Focus command : It will activate the Tab and focus the window. It doesn't always bring to front, but it highlight it and helps to find it. Usefull if you have a lot of windows and need to know where is the tab.
Fix query : fixed an inconsistency in the number of parameters in the query method call
NEW: parameter to use a ',' separate list of IP:PORT to connect. If you have too much browsers to check, you can point unique to a list of them. It allows to point to a browser on another IP, not only localhost, without the need of network tweak(as port redirect).


Still testing, but with this patches i can make a great use on Windows/Chrome. Hope it will work ok 
 on the other OS/Browser combinations.
It will need more changes for Windows/FF.