### PR TITLE
Windows compatibility improvements, add tab_id filter to bt text, add --focused to bt activate (Pr/21/master)

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -5,10 +5,11 @@ on: [push]
 jobs:
   build:
 
-    runs-on: [ubuntu-latest, windows-latest]
+    runs-on: ubuntu-latest
     strategy:
       # You can use PyPy versions in python-version. For example, pypy2 and pypy3
       matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: [3.5, 3.6, 3.7, 3.8]
 
     steps:
@@ -22,7 +23,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r requirements/base.txt
     - name: Display Python version
-      run: python -c "import sys; print(sys.version)"      
+      run: python -c "import sys; print(sys.version)"
 #    - name: Lint with flake8
 #      run: |
 #        pip install flake8

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -r requirements/base.txt
+        pip install -r requirements/test.txt
     - name: Display Python version
       run: python -c "import sys; print(sys.version)"
 #    - name: Lint with flake8

--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -1,0 +1,26 @@
+name: Upload Python Package
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools wheel twine
+    - name: Build and publish
+      env:
+        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+      run: |
+        python setup.py sdist bdist_wheel
+        twine upload dist/*

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ brotab/node_modules
 node_modules
 tags
 npm-debug.log
+tmp

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+* add "--target" argument to disable automatic mediator discovery and be
+  able to specify mediator's host:port address. Multiple entries are
+  separated with a comma, e.g. --target "localhost:2000,127.0.0.1:3000"
+* add "--focused" argument to "activate" tab command. This will bring browser
+  into focus
+* automatically register native app manifest in the Windows Registry when doing
+  "bt install" (Windows only)
+* detect user's temporary directory (Windows-related fix)
+* use "notepad" editor for "bt move" command on Windows
+* add optional tab_ids filter to "bt text [tab_id]" command
+
 1.1.0 (2019-12-15)
 
 * add "query" command that allows for more fine-tuned querying of tabs

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -127,8 +127,7 @@ Testing:
 
 ```bash
 # bump bersion in brotab/__version__.py
-$ pandoc --from=markdown --to=rst --output=README.rst README.md
-$ python setup.py sdist bdist_wheel --universal
+$ python setup.py sdist bdist_wheel
 $ twine upload dist/*
 
 $ nvim CHANGELOG.md

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -61,6 +61,12 @@ fc close
 fo open
 fs search
 
+Getting data from PDF page:
+
+Firefox:
+var d = await window.PDFViewerApplication.pdfDocument.getData()
+Uint8Array(100194) [ 37, 80, 68, 70, 45, 49, 46, 51, 10, 37, … ]
+
 ## CompleBox
 
 Desired modes:

--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ positional arguments:
 
 optional arguments:
   -h, --help            show this help message and exit
+  --target TARGET_HOSTS
+                        Target hosts IP:Port
 ```
 
 ## Demo [TBD]

--- a/brotab/api.py
+++ b/brotab/api.py
@@ -99,6 +99,17 @@ class SingleMediatorAPI(object):
         self._get('/activate_tab/%s' % tab_id)
         #self._get('/activate_tab/%s' % strWindowTab)
 
+    def activateFocus_tab(self, args):
+        # args = self.filter_tabs(args)
+        if len(args) == 0:
+            return
+
+        strWindowTab = args[0]
+        prefix, window_id, tab_id = strWindowTab.split('.')
+        self._get('/activateFocus_tab/%s' % tab_id)
+        #self._get('/activate_tab/%s' % strWindowTab)
+        
+        
     def get_active_tabs(self, args) -> [str]:
         return [self.prefix_tab(tab) for tab in self._get('/get_active_tabs').split(',')]
 
@@ -197,7 +208,7 @@ class SingleMediatorAPI(object):
                 'SingleMediatorAPI: get_words: %s, match_regex: %s, join_with: %s',
                 tab_id, match_regex, join_with)
             words |= set(self._get(
-                '/get_words/%s?match_regex=%s&join_with=%s' % (tab_id, match_regex, join_with)
+                '/get_words/%s/?match_regex=%s&join_with=%s' % (tab_id, match_regex, join_with)
             ).splitlines())
 
         if not tab_ids:
@@ -278,6 +289,14 @@ class MultipleMediatorsAPI(object):
         for api in self._apis:
             api.activate_tab(args)
 
+    def activateFocus_tab(self, args):
+        if len(args) == 0:
+            print('Usage: brotab_client.py activateFocus_tab <#tab>')
+            return 2
+
+        for api in self._apis:
+            api.activateFocus_tab(args)
+            
     def get_active_tabs(self, args):
         return [api.get_active_tabs(args) for api in self._apis]
         #return ['%s\t%s' % (api.get_active_tabs(args), api) for api in self._apis]

--- a/brotab/api.py
+++ b/brotab/api.py
@@ -111,15 +111,6 @@ class SingleMediatorAPI(object):
         prefix, window_id, tab_id = args[0].split('.')
         self._get('/activate_tab/%s%s' % (tab_id, '?focused=1' if focused else ''))
 
-    def activateFocus_tab(self, args):
-        if len(args) == 0:
-            return
-
-        strWindowTab = args[0]
-        prefix, window_id, tab_id = strWindowTab.split('.')
-        self._get('/activateFocus_tab/%s' % tab_id)
-        #self._get('/activate_tab/%s' % strWindowTab)
-
     def get_active_tabs(self, args) -> [str]:
         return [self.prefix_tab(tab) for tab in self._get('/get_active_tabs').split(',')]
 
@@ -296,25 +287,8 @@ class MultipleMediatorsAPI(object):
         for api in self._apis:
             api.activate_tab(args, focused)
 
-    def activateFocus_tab(self, args):
-        if len(args) == 0:
-            print('Usage: brotab_client.py activateFocus_tab <#tab>')
-            return 2
-
-        for api in self._apis:
-            api.activateFocus_tab(args)
-            
     def get_active_tabs(self, args):
         return [api.get_active_tabs(args) for api in self._apis]
-        #return ['%s\t%s' % (api.get_active_tabs(args), api) for api in self._apis]
-
-    # def new_tab(self, args):
-    #     if len(args) <= 1:
-    #         print('Usage: brotab_client.py new_tab <f.|c.> <search query>')
-    #         return 2
-    #
-    #     for api in self._apis:
-    #         api.new_tab(args)
 
     def query_tabs(self, args, print_error=False):
         functions = [partial(api.query_tabs_safe, args, print_error)

--- a/brotab/api.py
+++ b/brotab/api.py
@@ -11,6 +11,8 @@ from urllib.parse import quote_plus
 from functools import partial
 from collections.abc import Mapping
 
+from typing import List
+
 from brotab.inout import edit_tabs_in_editor
 from brotab.inout import MultiPartForm
 from brotab.parallel import call_parallel
@@ -101,13 +103,13 @@ class SingleMediatorAPI(object):
                         tab_id in self._split_tabs(args))
         return self._get('/close_tabs/%s' % tabs)
 
-    def activate_tab(self, args):
+    def activate_tab(self, args: List[str], focused: bool):
         if len(args) == 0:
             return
 
-        strWindowTab = args[0]
-        prefix, window_id, tab_id = strWindowTab.split('.')
-        self._get('/activate_tab/%s' % tab_id)
+        # args: ['a.1.2']
+        prefix, window_id, tab_id = args[0].split('.')
+        self._get('/activate_tab/%s%s' % (tab_id, '?focused=1' if focused else ''))
 
     def activateFocus_tab(self, args):
         if len(args) == 0:
@@ -286,13 +288,13 @@ class MultipleMediatorsAPI(object):
         for api in self._apis:
             api.close_tabs(args)
 
-    def activate_tab(self, args):
+    def activate_tab(self, args: List[str], focused: bool):
         if len(args) == 0:
-            print('Usage: brotab_client.py activate_tab <#tab>')
+            print('Usage: brotab_client.py activate_tab [--focused] <#tab>')
             return 2
 
         for api in self._apis:
-            api.activate_tab(args)
+            api.activate_tab(args, focused)
 
     def activateFocus_tab(self, args):
         if len(args) == 0:

--- a/brotab/extension/background.js
+++ b/brotab/extension/background.js
@@ -523,7 +523,7 @@ port.onDisconnect.addListener(function() {
   console.log("Disconnected");
 });
 
-console.log("Connected to native app");
+console.log("Connected to native app " + NATIVE_APP_NAME);
 
 /*
 On a click on the browser action, send the app a message.

--- a/brotab/extension/background.js
+++ b/brotab/extension/background.js
@@ -37,10 +37,6 @@ class BrowserTabs {
     throw new Error('activate is not implemented');
   }
 
-  activateFocus(tab_id) {
-    throw new Error('activateFocus is not implemented');
-  }
-
   getActive(onSuccess) {
     throw new Error('getActive is not implemented');
   }
@@ -69,7 +65,7 @@ class FirefoxTabs extends BrowserTabs {
 
   query(queryInfo, onSuccess) {
     this._browser.tabs.query(queryInfo)
-      .then(onSuccess, 
+      .then(onSuccess,
             (error) => console.log(`Error execvuting queryTabs: ${error}`)
             );
   }
@@ -117,14 +113,9 @@ class FirefoxTabs extends BrowserTabs {
   activate(tab_id, focused) {
     this._browser.tabs.update(tab_id, {'active': true});
     this._browser.tabs.get(tab_id, function(tab) {
-      browser.windows.update(tab.windowId,{focused: focused});
+      browser.windows.update(tab.windowId, {focused: focused});
     });
   }
-
-  activateFocus(tab_id) {
-    this.activate(tab_id); //this._browser.tabs.update(tab_id, {'active': true});
-  }
-
 }
 
 class ChromeTabs extends BrowserTabs {
@@ -135,41 +126,17 @@ class ChromeTabs extends BrowserTabs {
   activate(tab_id, focused) {
     this._browser.tabs.update(tab_id, {'active': true});
     this._browser.tabs.get(tab_id, function(tab) {
-      chrome.windows.update(tab.windowId,{focused: focused});
+      chrome.windows.update(tab.windowId, {focused: focused});
     });
   }
-
-  activateFocus(tab_id) {
-    this._browser.tabs.update(tab_id, {'active': true});
-    this._browser.tabs.get(tab_id, function(tab) {
-      chrome.windows.update(tab.windowId,{focused: true});
-    });
-
-//Alternative to  this._browser.tabs.update(tab_id, {'active': true});
-//    chrome.tabs.get(tab_id, function(tab) {
-//      chrome.tabs.highlight({'tabs': tab.index}, function() {});
-//    });
-  }
-
-
-// Try to pass 2 parameters
-//  activate(win_id, tab_id) {
-//    this._browser.tabs.update(tab_id, {'active': true});
-//    if (win_id > 0) { chrome.windows.update(win_id ,{focused: true});
-//     };
-/////Alternative
-//    //chrome.tabs.get(tab_id, function(tab) {
-//    //  chrome.tabs.highlight({'tabs': tab.index}, function() {});
-//    //});
-//  }
 
 
 //  query(queryInfo, onSuccess, onFailure) {
 //    this._browser.tabs.query(queryInfo)
 //      .then(onSuccess, onFailure);
 //  }
-  
-  query(queryInfo, onSuccess) {  
+
+  query(queryInfo, onSuccess) {
     this._browser.tabs.query(queryInfo,onSuccess);
   }
 
@@ -288,11 +255,11 @@ function queryTabs(query_info) {
   try {
     let query = atob(query_info)
     query = JSON.parse(query)
-    
+
     integerKeys = {'windowId': null, 'index': null};
     booleanKeys = {'active': null, 'pinned': null, 'audible': null, 'muted': null, 'highlighted': null,
       'discarded': null, 'autoDiscardable': null, 'currentWindow': null, 'lastFocusedWindow': null};
-    
+
     query = Object.entries(query).reduce((o, [k,v]) => {
       if (booleanKeys.hasOwnProperty(k) && typeof v != 'boolean') {
         if (v.toLowerCase() == 'true')
@@ -308,9 +275,9 @@ function queryTabs(query_info) {
         o[k] = v;
       return o;
     }, {})
-    
+
     //browserTabs.query(query, queryTabsOnSuccess, queryTabsOnFailure);
-    browserTabs.query(query, queryTabsOnSuccess);    
+    browserTabs.query(query, queryTabsOnSuccess);
   }
   catch(error) {
     queryTabsOnFailure(error);
@@ -370,11 +337,6 @@ function createTab(url) {
 function activateTab(tab_id, focused) {
   browserTabs.activate(tab_id, focused);
 }
-
-function activateFocusTab(tab_id) {
-  browserTabs.activateFocus(tab_id);
-}
-
 
 function getActiveTabs() {
   browserTabs.getActive(tabs => {
@@ -546,11 +508,6 @@ port.onMessage.addListener((command) => {
   else if (command['name'] == 'activate_tab') {
     console.log('Activating tab:', command['tab_id']);
     activateTab(command['tab_id'], !!command['focused']);
-  }
-
-  else if (command['name'] == 'activateFocus_tab') {
-    console.log('Activating tab:', command['tab_id']);
-    activateFocusTab(command['tab_id']);
   }
 
   else if (command['name'] == 'get_active_tabs') {

--- a/brotab/extension/background.js
+++ b/brotab/extension/background.js
@@ -114,8 +114,11 @@ class FirefoxTabs extends BrowserTabs {
       return "firefox";
   }
 
-  activate(tab_id) {
+  activate(tab_id, focused) {
     this._browser.tabs.update(tab_id, {'active': true});
+    this._browser.tabs.get(tab_id, function(tab) {
+      browser.windows.update(tab.windowId,{focused: focused});
+    });
   }
 
   activateFocus(tab_id) {
@@ -129,8 +132,11 @@ class ChromeTabs extends BrowserTabs {
     this._browser.tabs.query(queryInfo, onSuccess);
   }
 
-  activate(tab_id) {
+  activate(tab_id, focused) {
     this._browser.tabs.update(tab_id, {'active': true});
+    this._browser.tabs.get(tab_id, function(tab) {
+      chrome.windows.update(tab.windowId,{focused: focused});
+    });
   }
 
   activateFocus(tab_id) {
@@ -361,8 +367,8 @@ function createTab(url) {
   });
 }
 
-function activateTab(tab_id) {
-  browserTabs.activate(tab_id);
+function activateTab(tab_id, focused) {
+  browserTabs.activate(tab_id, focused);
 }
 
 function activateFocusTab(tab_id) {
@@ -539,7 +545,7 @@ port.onMessage.addListener((command) => {
 
   else if (command['name'] == 'activate_tab') {
     console.log('Activating tab:', command['tab_id']);
-    activateTab(command['tab_id']);
+    activateTab(command['tab_id'], !!command['focused']);
   }
 
   else if (command['name'] == 'activateFocus_tab') {

--- a/brotab/extension/background.js
+++ b/brotab/extension/background.js
@@ -58,16 +58,11 @@ class FirefoxTabs extends BrowserTabs {
     );
   }
 
-//  query(queryInfo, onSuccess, onFailure) {
-//    this._browser.tabs.query(queryInfo)
-//      .then(onSuccess, onFailure);
-//  }
-
   query(queryInfo, onSuccess) {
-    this._browser.tabs.query(queryInfo)
-      .then(onSuccess,
-            (error) => console.log(`Error execvuting queryTabs: ${error}`)
-            );
+    this._browser.tabs.query(queryInfo).then(
+      onSuccess,
+      (error) => console.log(`Error executing queryTabs: ${error}`)
+    );
   }
 
   close(tab_ids, onSuccess) {
@@ -130,14 +125,8 @@ class ChromeTabs extends BrowserTabs {
     });
   }
 
-
-//  query(queryInfo, onSuccess, onFailure) {
-//    this._browser.tabs.query(queryInfo)
-//      .then(onSuccess, onFailure);
-//  }
-
   query(queryInfo, onSuccess) {
-    this._browser.tabs.query(queryInfo,onSuccess);
+    this._browser.tabs.query(queryInfo, onSuccess);
   }
 
   close(tab_ids, onSuccess) {
@@ -276,7 +265,6 @@ function queryTabs(query_info) {
       return o;
     }, {})
 
-    //browserTabs.query(query, queryTabsOnSuccess, queryTabsOnFailure);
     browserTabs.query(query, queryTabsOnSuccess);
   }
   catch(error) {

--- a/brotab/extension/chrome/background.js
+++ b/brotab/extension/chrome/background.js
@@ -523,7 +523,7 @@ port.onDisconnect.addListener(function() {
   console.log("Disconnected");
 });
 
-console.log("Connected to native app");
+console.log("Connected to native app " + NATIVE_APP_NAME);
 
 /*
 On a click on the browser action, send the app a message.

--- a/brotab/extension/chrome/background.js
+++ b/brotab/extension/chrome/background.js
@@ -37,10 +37,6 @@ class BrowserTabs {
     throw new Error('activate is not implemented');
   }
 
-  activateFocus(tab_id) {
-    throw new Error('activateFocus is not implemented');
-  }
-
   getActive(onSuccess) {
     throw new Error('getActive is not implemented');
   }
@@ -69,7 +65,7 @@ class FirefoxTabs extends BrowserTabs {
 
   query(queryInfo, onSuccess) {
     this._browser.tabs.query(queryInfo)
-      .then(onSuccess, 
+      .then(onSuccess,
             (error) => console.log(`Error execvuting queryTabs: ${error}`)
             );
   }
@@ -117,14 +113,9 @@ class FirefoxTabs extends BrowserTabs {
   activate(tab_id, focused) {
     this._browser.tabs.update(tab_id, {'active': true});
     this._browser.tabs.get(tab_id, function(tab) {
-      browser.windows.update(tab.windowId,{focused: focused});
+      browser.windows.update(tab.windowId, {focused: focused});
     });
   }
-
-  activateFocus(tab_id) {
-    this.activate(tab_id); //this._browser.tabs.update(tab_id, {'active': true});
-  }
-
 }
 
 class ChromeTabs extends BrowserTabs {
@@ -135,41 +126,17 @@ class ChromeTabs extends BrowserTabs {
   activate(tab_id, focused) {
     this._browser.tabs.update(tab_id, {'active': true});
     this._browser.tabs.get(tab_id, function(tab) {
-      chrome.windows.update(tab.windowId,{focused: focused});
+      chrome.windows.update(tab.windowId, {focused: focused});
     });
   }
-
-  activateFocus(tab_id) {
-    this._browser.tabs.update(tab_id, {'active': true});
-    this._browser.tabs.get(tab_id, function(tab) {
-      chrome.windows.update(tab.windowId,{focused: true});
-    });
-
-//Alternative to  this._browser.tabs.update(tab_id, {'active': true});
-//    chrome.tabs.get(tab_id, function(tab) {
-//      chrome.tabs.highlight({'tabs': tab.index}, function() {});
-//    });
-  }
-
-
-// Try to pass 2 parameters
-//  activate(win_id, tab_id) {
-//    this._browser.tabs.update(tab_id, {'active': true});
-//    if (win_id > 0) { chrome.windows.update(win_id ,{focused: true});
-//     };
-/////Alternative
-//    //chrome.tabs.get(tab_id, function(tab) {
-//    //  chrome.tabs.highlight({'tabs': tab.index}, function() {});
-//    //});
-//  }
 
 
 //  query(queryInfo, onSuccess, onFailure) {
 //    this._browser.tabs.query(queryInfo)
 //      .then(onSuccess, onFailure);
 //  }
-  
-  query(queryInfo, onSuccess) {  
+
+  query(queryInfo, onSuccess) {
     this._browser.tabs.query(queryInfo,onSuccess);
   }
 
@@ -288,11 +255,11 @@ function queryTabs(query_info) {
   try {
     let query = atob(query_info)
     query = JSON.parse(query)
-    
+
     integerKeys = {'windowId': null, 'index': null};
     booleanKeys = {'active': null, 'pinned': null, 'audible': null, 'muted': null, 'highlighted': null,
       'discarded': null, 'autoDiscardable': null, 'currentWindow': null, 'lastFocusedWindow': null};
-    
+
     query = Object.entries(query).reduce((o, [k,v]) => {
       if (booleanKeys.hasOwnProperty(k) && typeof v != 'boolean') {
         if (v.toLowerCase() == 'true')
@@ -308,9 +275,9 @@ function queryTabs(query_info) {
         o[k] = v;
       return o;
     }, {})
-    
+
     //browserTabs.query(query, queryTabsOnSuccess, queryTabsOnFailure);
-    browserTabs.query(query, queryTabsOnSuccess);    
+    browserTabs.query(query, queryTabsOnSuccess);
   }
   catch(error) {
     queryTabsOnFailure(error);
@@ -370,11 +337,6 @@ function createTab(url) {
 function activateTab(tab_id, focused) {
   browserTabs.activate(tab_id, focused);
 }
-
-function activateFocusTab(tab_id) {
-  browserTabs.activateFocus(tab_id);
-}
-
 
 function getActiveTabs() {
   browserTabs.getActive(tabs => {
@@ -546,11 +508,6 @@ port.onMessage.addListener((command) => {
   else if (command['name'] == 'activate_tab') {
     console.log('Activating tab:', command['tab_id']);
     activateTab(command['tab_id'], !!command['focused']);
-  }
-
-  else if (command['name'] == 'activateFocus_tab') {
-    console.log('Activating tab:', command['tab_id']);
-    activateFocusTab(command['tab_id']);
   }
 
   else if (command['name'] == 'get_active_tabs') {

--- a/brotab/extension/chrome/background.js
+++ b/brotab/extension/chrome/background.js
@@ -114,8 +114,11 @@ class FirefoxTabs extends BrowserTabs {
       return "firefox";
   }
 
-  activate(tab_id) {
+  activate(tab_id, focused) {
     this._browser.tabs.update(tab_id, {'active': true});
+    this._browser.tabs.get(tab_id, function(tab) {
+      browser.windows.update(tab.windowId,{focused: focused});
+    });
   }
 
   activateFocus(tab_id) {
@@ -129,8 +132,11 @@ class ChromeTabs extends BrowserTabs {
     this._browser.tabs.query(queryInfo, onSuccess);
   }
 
-  activate(tab_id) {
+  activate(tab_id, focused) {
     this._browser.tabs.update(tab_id, {'active': true});
+    this._browser.tabs.get(tab_id, function(tab) {
+      chrome.windows.update(tab.windowId,{focused: focused});
+    });
   }
 
   activateFocus(tab_id) {
@@ -361,8 +367,8 @@ function createTab(url) {
   });
 }
 
-function activateTab(tab_id) {
-  browserTabs.activate(tab_id);
+function activateTab(tab_id, focused) {
+  browserTabs.activate(tab_id, focused);
 }
 
 function activateFocusTab(tab_id) {
@@ -539,7 +545,7 @@ port.onMessage.addListener((command) => {
 
   else if (command['name'] == 'activate_tab') {
     console.log('Activating tab:', command['tab_id']);
-    activateTab(command['tab_id']);
+    activateTab(command['tab_id'], !!command['focused']);
   }
 
   else if (command['name'] == 'activateFocus_tab') {

--- a/brotab/extension/chrome/background.js
+++ b/brotab/extension/chrome/background.js
@@ -58,16 +58,11 @@ class FirefoxTabs extends BrowserTabs {
     );
   }
 
-//  query(queryInfo, onSuccess, onFailure) {
-//    this._browser.tabs.query(queryInfo)
-//      .then(onSuccess, onFailure);
-//  }
-
   query(queryInfo, onSuccess) {
-    this._browser.tabs.query(queryInfo)
-      .then(onSuccess,
-            (error) => console.log(`Error execvuting queryTabs: ${error}`)
-            );
+    this._browser.tabs.query(queryInfo).then(
+      onSuccess,
+      (error) => console.log(`Error executing queryTabs: ${error}`)
+    );
   }
 
   close(tab_ids, onSuccess) {
@@ -130,14 +125,8 @@ class ChromeTabs extends BrowserTabs {
     });
   }
 
-
-//  query(queryInfo, onSuccess, onFailure) {
-//    this._browser.tabs.query(queryInfo)
-//      .then(onSuccess, onFailure);
-//  }
-
   query(queryInfo, onSuccess) {
-    this._browser.tabs.query(queryInfo,onSuccess);
+    this._browser.tabs.query(queryInfo, onSuccess);
   }
 
   close(tab_ids, onSuccess) {
@@ -276,7 +265,6 @@ function queryTabs(query_info) {
       return o;
     }, {})
 
-    //browserTabs.query(query, queryTabsOnSuccess, queryTabsOnFailure);
     browserTabs.query(query, queryTabsOnSuccess);
   }
   catch(error) {

--- a/brotab/extension/firefox/background.js
+++ b/brotab/extension/firefox/background.js
@@ -523,7 +523,7 @@ port.onDisconnect.addListener(function() {
   console.log("Disconnected");
 });
 
-console.log("Connected to native app");
+console.log("Connected to native app " + NATIVE_APP_NAME);
 
 /*
 On a click on the browser action, send the app a message.

--- a/brotab/extension/firefox/background.js
+++ b/brotab/extension/firefox/background.js
@@ -37,10 +37,6 @@ class BrowserTabs {
     throw new Error('activate is not implemented');
   }
 
-  activateFocus(tab_id) {
-    throw new Error('activateFocus is not implemented');
-  }
-
   getActive(onSuccess) {
     throw new Error('getActive is not implemented');
   }
@@ -69,7 +65,7 @@ class FirefoxTabs extends BrowserTabs {
 
   query(queryInfo, onSuccess) {
     this._browser.tabs.query(queryInfo)
-      .then(onSuccess, 
+      .then(onSuccess,
             (error) => console.log(`Error execvuting queryTabs: ${error}`)
             );
   }
@@ -117,14 +113,9 @@ class FirefoxTabs extends BrowserTabs {
   activate(tab_id, focused) {
     this._browser.tabs.update(tab_id, {'active': true});
     this._browser.tabs.get(tab_id, function(tab) {
-      browser.windows.update(tab.windowId,{focused: focused});
+      browser.windows.update(tab.windowId, {focused: focused});
     });
   }
-
-  activateFocus(tab_id) {
-    this.activate(tab_id); //this._browser.tabs.update(tab_id, {'active': true});
-  }
-
 }
 
 class ChromeTabs extends BrowserTabs {
@@ -135,41 +126,17 @@ class ChromeTabs extends BrowserTabs {
   activate(tab_id, focused) {
     this._browser.tabs.update(tab_id, {'active': true});
     this._browser.tabs.get(tab_id, function(tab) {
-      chrome.windows.update(tab.windowId,{focused: focused});
+      chrome.windows.update(tab.windowId, {focused: focused});
     });
   }
-
-  activateFocus(tab_id) {
-    this._browser.tabs.update(tab_id, {'active': true});
-    this._browser.tabs.get(tab_id, function(tab) {
-      chrome.windows.update(tab.windowId,{focused: true});
-    });
-
-//Alternative to  this._browser.tabs.update(tab_id, {'active': true});
-//    chrome.tabs.get(tab_id, function(tab) {
-//      chrome.tabs.highlight({'tabs': tab.index}, function() {});
-//    });
-  }
-
-
-// Try to pass 2 parameters
-//  activate(win_id, tab_id) {
-//    this._browser.tabs.update(tab_id, {'active': true});
-//    if (win_id > 0) { chrome.windows.update(win_id ,{focused: true});
-//     };
-/////Alternative
-//    //chrome.tabs.get(tab_id, function(tab) {
-//    //  chrome.tabs.highlight({'tabs': tab.index}, function() {});
-//    //});
-//  }
 
 
 //  query(queryInfo, onSuccess, onFailure) {
 //    this._browser.tabs.query(queryInfo)
 //      .then(onSuccess, onFailure);
 //  }
-  
-  query(queryInfo, onSuccess) {  
+
+  query(queryInfo, onSuccess) {
     this._browser.tabs.query(queryInfo,onSuccess);
   }
 
@@ -288,11 +255,11 @@ function queryTabs(query_info) {
   try {
     let query = atob(query_info)
     query = JSON.parse(query)
-    
+
     integerKeys = {'windowId': null, 'index': null};
     booleanKeys = {'active': null, 'pinned': null, 'audible': null, 'muted': null, 'highlighted': null,
       'discarded': null, 'autoDiscardable': null, 'currentWindow': null, 'lastFocusedWindow': null};
-    
+
     query = Object.entries(query).reduce((o, [k,v]) => {
       if (booleanKeys.hasOwnProperty(k) && typeof v != 'boolean') {
         if (v.toLowerCase() == 'true')
@@ -308,9 +275,9 @@ function queryTabs(query_info) {
         o[k] = v;
       return o;
     }, {})
-    
+
     //browserTabs.query(query, queryTabsOnSuccess, queryTabsOnFailure);
-    browserTabs.query(query, queryTabsOnSuccess);    
+    browserTabs.query(query, queryTabsOnSuccess);
   }
   catch(error) {
     queryTabsOnFailure(error);
@@ -370,11 +337,6 @@ function createTab(url) {
 function activateTab(tab_id, focused) {
   browserTabs.activate(tab_id, focused);
 }
-
-function activateFocusTab(tab_id) {
-  browserTabs.activateFocus(tab_id);
-}
-
 
 function getActiveTabs() {
   browserTabs.getActive(tabs => {
@@ -546,11 +508,6 @@ port.onMessage.addListener((command) => {
   else if (command['name'] == 'activate_tab') {
     console.log('Activating tab:', command['tab_id']);
     activateTab(command['tab_id'], !!command['focused']);
-  }
-
-  else if (command['name'] == 'activateFocus_tab') {
-    console.log('Activating tab:', command['tab_id']);
-    activateFocusTab(command['tab_id']);
   }
 
   else if (command['name'] == 'get_active_tabs') {

--- a/brotab/extension/firefox/background.js
+++ b/brotab/extension/firefox/background.js
@@ -114,8 +114,11 @@ class FirefoxTabs extends BrowserTabs {
       return "firefox";
   }
 
-  activate(tab_id) {
+  activate(tab_id, focused) {
     this._browser.tabs.update(tab_id, {'active': true});
+    this._browser.tabs.get(tab_id, function(tab) {
+      browser.windows.update(tab.windowId,{focused: focused});
+    });
   }
 
   activateFocus(tab_id) {
@@ -129,8 +132,11 @@ class ChromeTabs extends BrowserTabs {
     this._browser.tabs.query(queryInfo, onSuccess);
   }
 
-  activate(tab_id) {
+  activate(tab_id, focused) {
     this._browser.tabs.update(tab_id, {'active': true});
+    this._browser.tabs.get(tab_id, function(tab) {
+      chrome.windows.update(tab.windowId,{focused: focused});
+    });
   }
 
   activateFocus(tab_id) {
@@ -361,8 +367,8 @@ function createTab(url) {
   });
 }
 
-function activateTab(tab_id) {
-  browserTabs.activate(tab_id);
+function activateTab(tab_id, focused) {
+  browserTabs.activate(tab_id, focused);
 }
 
 function activateFocusTab(tab_id) {
@@ -539,7 +545,7 @@ port.onMessage.addListener((command) => {
 
   else if (command['name'] == 'activate_tab') {
     console.log('Activating tab:', command['tab_id']);
-    activateTab(command['tab_id']);
+    activateTab(command['tab_id'], !!command['focused']);
   }
 
   else if (command['name'] == 'activateFocus_tab') {

--- a/brotab/extension/firefox/background.js
+++ b/brotab/extension/firefox/background.js
@@ -58,16 +58,11 @@ class FirefoxTabs extends BrowserTabs {
     );
   }
 
-//  query(queryInfo, onSuccess, onFailure) {
-//    this._browser.tabs.query(queryInfo)
-//      .then(onSuccess, onFailure);
-//  }
-
   query(queryInfo, onSuccess) {
-    this._browser.tabs.query(queryInfo)
-      .then(onSuccess,
-            (error) => console.log(`Error execvuting queryTabs: ${error}`)
-            );
+    this._browser.tabs.query(queryInfo).then(
+      onSuccess,
+      (error) => console.log(`Error executing queryTabs: ${error}`)
+    );
   }
 
   close(tab_ids, onSuccess) {
@@ -130,14 +125,8 @@ class ChromeTabs extends BrowserTabs {
     });
   }
 
-
-//  query(queryInfo, onSuccess, onFailure) {
-//    this._browser.tabs.query(queryInfo)
-//      .then(onSuccess, onFailure);
-//  }
-
   query(queryInfo, onSuccess) {
-    this._browser.tabs.query(queryInfo,onSuccess);
+    this._browser.tabs.query(queryInfo, onSuccess);
   }
 
   close(tab_ids, onSuccess) {
@@ -276,7 +265,6 @@ function queryTabs(query_info) {
       return o;
     }, {})
 
-    //browserTabs.query(query, queryTabsOnSuccess, queryTabsOnFailure);
     browserTabs.query(query, queryTabsOnSuccess);
   }
   catch(error) {

--- a/brotab/inout.py
+++ b/brotab/inout.py
@@ -38,7 +38,7 @@ def edit_tabs_in_editor(tabs_before):
         try:
             #check_call([os.environ.get('EDITOR', 'notepad'), file_name]) #            check_call([os.environ.get('EDITOR', 'nvim'), file_.name])
             Editor = 'notepad' if (platform.system()=='Windows') else 'nvim'
-            check_call([os.environ.get('EDITOR', Editor), file_.name])
+            check_call([os.environ.get('EDITOR', Editor), file_name])
             tabs_after = load_tabs_from_file(file_name)
             return tabs_after
         except CalledProcessError:

--- a/brotab/inout.py
+++ b/brotab/inout.py
@@ -9,34 +9,40 @@ from tempfile import NamedTemporaryFile
 from subprocess import check_call, CalledProcessError
 
 
-def is_port_accepting_connections(port):
+def is_port_accepting_connections(port, host='127.0.0.1'):
     s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     s.settimeout(0.100)
-    result = s.connect_ex(('127.0.0.1', port))
+    result = s.connect_ex((host, port))
     s.close()
     return result == 0
 
 
 def save_tabs_to_file(tabs, filename):
-    with open(filename, 'w') as file_:
+    with open(filename, 'w', encoding='utf-8') as file_:
         file_.write('\n'.join(tabs))
 
 
 def load_tabs_from_file(filename):
-    with open(filename) as file_:
-        return [line.strip() for line in file_.readlines()]
+    with open(filename, encoding='utf-8') as file_:
+        Lines = [line.strip() for line in file_.readlines()]
+    if os.path.exists(filename):
+        os.remove(filename)
+    return Lines
 
 
 def edit_tabs_in_editor(tabs_before):
     with NamedTemporaryFile() as file_:
-        save_tabs_to_file(tabs_before, file_.name)
+        file_name=file_.name
+        file_.close()
+        save_tabs_to_file(tabs_before, file_name)
         try:
-            check_call([os.environ.get('EDITOR', 'nvim'), file_.name])
-            tabs_after = load_tabs_from_file(file_.name)
+            #check_call([os.environ.get('EDITOR', 'notepad'), file_name]) #            check_call([os.environ.get('EDITOR', 'nvim'), file_.name])
+            Editor = 'notepad' if (platform.system()=='Windows') else 'nvim'
+            check_call([os.environ.get('EDITOR', Editor), file_.name])
+            tabs_after = load_tabs_from_file(file_name)
             return tabs_after
         except CalledProcessError:
             return None
-
 
 def read_stdin():
     if select.select([sys.stdin, ], [], [], 1.0)[0]:

--- a/brotab/inout.py
+++ b/brotab/inout.py
@@ -4,6 +4,7 @@ import sys
 import uuid
 import select
 import socket
+import tempfile
 import mimetypes
 from tempfile import NamedTemporaryFile
 from subprocess import check_call, CalledProcessError
@@ -13,6 +14,11 @@ from brotab.platform import get_editor
 
 MIN_MEDIATOR_PORT = 4625
 MAX_MEDIATOR_PORT = MIN_MEDIATOR_PORT + 10
+
+
+def in_temp_dir(filename) -> str:
+    temp_dir = tempfile.gettempdir()
+    return os.path.join(temp_dir, filename)
 
 
 def get_mediator_ports() -> Iterable:

--- a/brotab/inout.py
+++ b/brotab/inout.py
@@ -78,6 +78,10 @@ def read_stdin():
     return ''
 
 
+def stdout_buffer_write(message):
+    return sys.stdout.buffer.write(message)
+
+
 # Taken from https://pymotw.com/3/urllib.request/
 class MultiPartForm:
     """Accumulate the data to be used when posting a form."""

--- a/brotab/inout.py
+++ b/brotab/inout.py
@@ -8,6 +8,8 @@ import mimetypes
 from tempfile import NamedTemporaryFile
 from subprocess import check_call, CalledProcessError
 
+from brotab.platform import get_editor
+
 
 def is_port_accepting_connections(port, host='127.0.0.1'):
     s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
@@ -30,15 +32,17 @@ def load_tabs_from_file(filename):
     return Lines
 
 
+def run_editor(executable: str, filename: str):
+    return check_call([executable, filename])
+
+
 def edit_tabs_in_editor(tabs_before):
     with NamedTemporaryFile() as file_:
-        file_name=file_.name
+        file_name = file_.name
         file_.close()
         save_tabs_to_file(tabs_before, file_name)
         try:
-            #check_call([os.environ.get('EDITOR', 'notepad'), file_name]) #            check_call([os.environ.get('EDITOR', 'nvim'), file_.name])
-            Editor = 'notepad' if (platform.system()=='Windows') else 'nvim'
-            check_call([os.environ.get('EDITOR', Editor), file_name])
+            run_editor(get_editor(), file_name)
             tabs_after = load_tabs_from_file(file_name)
             return tabs_after
         except CalledProcessError:

--- a/brotab/inout.py
+++ b/brotab/inout.py
@@ -24,12 +24,14 @@ def save_tabs_to_file(tabs, filename):
         file_.write('\n'.join(tabs))
 
 
-def load_tabs_from_file(filename):
-    with open(filename, encoding='utf-8') as file_:
-        Lines = [line.strip() for line in file_.readlines()]
+def maybe_remove_file(filename):
     if os.path.exists(filename):
         os.remove(filename)
-    return Lines
+
+
+def load_tabs_from_file(filename):
+    with open(filename, encoding='utf-8') as file_:
+        return [line.strip() for line in file_.readlines()]
 
 
 def run_editor(executable: str, filename: str):
@@ -44,6 +46,7 @@ def edit_tabs_in_editor(tabs_before):
         try:
             run_editor(get_editor(), file_name)
             tabs_after = load_tabs_from_file(file_name)
+            maybe_remove_file(file_name)
             return tabs_after
         except CalledProcessError:
             return None

--- a/brotab/inout.py
+++ b/brotab/inout.py
@@ -7,8 +7,23 @@ import socket
 import mimetypes
 from tempfile import NamedTemporaryFile
 from subprocess import check_call, CalledProcessError
+from typing import Iterable
 
 from brotab.platform import get_editor
+
+MIN_MEDIATOR_PORT = 4625
+MAX_MEDIATOR_PORT = MIN_MEDIATOR_PORT + 10
+
+
+def get_mediator_ports() -> Iterable:
+    return range(MIN_MEDIATOR_PORT, MAX_MEDIATOR_PORT)
+
+
+def get_free_tcp_port(start=1025, end=65536, host='127.0.0.1'):
+    for port in range(start, end):
+        if not is_port_accepting_connections(port, host):
+            return port
+    return RuntimeError('Cannot find free port in range %d:%d' % (start, end))
 
 
 def is_port_accepting_connections(port, host='127.0.0.1'):

--- a/brotab/main.py
+++ b/brotab/main.py
@@ -60,6 +60,7 @@ from urllib.parse import quote_plus, quote
 
 from brotab.inout import is_port_accepting_connections
 from brotab.inout import read_stdin
+from brotab.inout import get_mediator_ports
 from brotab.utils import split_tab_ids, get_file_size, encode_query
 from brotab.search.query import query
 from brotab.search.index import index
@@ -70,9 +71,6 @@ from brotab.const import \
     DEFAULT_GET_TEXT_DELIMITER_REGEX, \
     DEFAULT_GET_TEXT_REPLACE_WITH
 
-
-MIN_MEDIATOR_PORT = 4625
-MAX_MEDIATOR_PORT = MIN_MEDIATOR_PORT + 10
 
 FORMAT = '%(asctime)-15s %(levelname)-10s %(message)s'
 logging.basicConfig(
@@ -89,18 +87,14 @@ def create_clients(args=None):
         d=vars(args)
         if d['targetHosts'] is not None:
             targetHosts = d['targetHosts'].split(',')
-    #print(targetHosts)
     if targetHosts is not None:
-        #ports = range(MIN_MEDIATOR_PORT, MAX_MEDIATOR_PORT)
         hosts = [i.split(':')[0] for i in targetHosts]
-        #print(hosts)
         ports = [int(i.split(':')[1]) for i in targetHosts]
-        #print(ports)
         result = [SingleMediatorAPI(prefix, host=host, port=port)
                   for prefix, host, port in zip(ascii_lowercase, hosts, ports)
                   if is_port_accepting_connections(port,host)]
     else:
-        ports = range(MIN_MEDIATOR_PORT, MAX_MEDIATOR_PORT)
+        ports = get_mediator_ports()
         result = [SingleMediatorAPI(prefix, port=port)
                   for prefix, port in zip(ascii_lowercase, ports)
                   if is_port_accepting_connections(port)]

--- a/brotab/main.py
+++ b/brotab/main.py
@@ -155,9 +155,8 @@ def close_tabs(args):
 
 def activate_tab(args):
     logger.info('Activating tab: %s', args.tab_id)
-    #api = MultipleMediatorsAPI([SingleMediatorAPI('f')])
     api = MultipleMediatorsAPI(create_clients(args))
-    api.activate_tab(args.tab_id)
+    api.activate_tab(args.tab_id, args.focused)
 
 def activateFocus_tab(args):
     logger.info('Activating tab: %s', args.tab_id)
@@ -415,6 +414,8 @@ def parse_args(args):
     parser_activate_tab.set_defaults(func=activate_tab)
     parser_activate_tab.add_argument('tab_id', type=str, nargs=1,
                                      help='Tab ID to activate')
+    parser_activate_tab.add_argument('--focused', action='store_const', const=True, default=None,
+                                     help='make browser focused after tab activation (default: False)')
 
     parser_activateFocus_tab = subparsers.add_parser(
         'focus',

--- a/brotab/main.py
+++ b/brotab/main.py
@@ -171,7 +171,7 @@ def activateFocus_tab(args):
     api = MultipleMediatorsAPI(create_clients(args))
     api.activateFocus_tab(args.tab_id)
 
-    
+
 def show_active_tabs(args):
     logger.info('Showing active tabs: %s', args)
     #api = MultipleMediatorsAPI([SingleMediatorAPI('f')])
@@ -376,7 +376,7 @@ def parse_args(args):
         ''')
 
     parser.add_argument('-target', dest = 'targetHosts', help='Target hosts IP:Port')
-    
+
     subparsers = parser.add_subparsers()
     parser.set_defaults(func=partial(no_command, parser))
 
@@ -431,8 +431,8 @@ def parse_args(args):
     parser_activateFocus_tab.set_defaults(func=activateFocus_tab)
     parser_activateFocus_tab.add_argument('tab_id', type=str, nargs=1,
                                      help='Tab ID to focus')
-                                     
-                                     
+
+
     parser_active_tab = subparsers.add_parser(
         'active',
         help='''
@@ -478,7 +478,7 @@ def parse_args(args):
         help='tabs are highlighted')
     parser_query_tabs.add_argument('-highlighted', action='store_const', const=False, default=None,
         help='tabs not are highlighted')
-    parser_query_tabs.add_argument('+discarded', action='store_const', const=True, default=None,  
+    parser_query_tabs.add_argument('+discarded', action='store_const', const=True, default=None,
         help='tabs are discarded i.e. unloaded from memory but still visible in the tab strip.')
     parser_query_tabs.add_argument('-discarded', action='store_const', const=False, default=None,
         help='tabs are not discarded i.e. unloaded from memory but still visible in the tab strip.')

--- a/brotab/main.py
+++ b/brotab/main.py
@@ -158,12 +158,6 @@ def activate_tab(args):
     api = MultipleMediatorsAPI(create_clients(args))
     api.activate_tab(args.tab_id, args.focused)
 
-def activateFocus_tab(args):
-    logger.info('Activating tab: %s', args.tab_id)
-    #api = MultipleMediatorsAPI([SingleMediatorAPI('f')])
-    api = MultipleMediatorsAPI(create_clients(args))
-    api.activateFocus_tab(args.tab_id)
-
 
 def show_active_tabs(args):
     logger.info('Showing active tabs: %s', args)
@@ -416,17 +410,6 @@ def parse_args(args):
                                      help='Tab ID to activate')
     parser_activate_tab.add_argument('--focused', action='store_const', const=True, default=None,
                                      help='make browser focused after tab activation (default: False)')
-
-    parser_activateFocus_tab = subparsers.add_parser(
-        'focus',
-        help='''
-        focus given tab ID. Tab ID should be in the following format:
-        "<prefix>.<window_id>.<tab_id>"
-        ''')
-    parser_activateFocus_tab.set_defaults(func=activateFocus_tab)
-    parser_activateFocus_tab.add_argument('tab_id', type=str, nargs=1,
-                                     help='Tab ID to focus')
-
 
     parser_active_tab = subparsers.add_parser(
         'active',

--- a/brotab/main.py
+++ b/brotab/main.py
@@ -64,6 +64,7 @@ from brotab.inout import is_port_accepting_connections
 from brotab.inout import read_stdin
 from brotab.inout import get_mediator_ports
 from brotab.inout import in_temp_dir
+from brotab.inout import stdout_buffer_write
 from brotab.platform import is_windows
 from brotab.platform import register_native_manifest_windows_chrome
 from brotab.platform import register_native_manifest_windows_firefox
@@ -263,7 +264,7 @@ def get_text(args):
 
     message = '\n'.join(tabs) + '\n'
     if args.tsv is None:
-        sys.stdout.buffer.write(message.encode('utf8'))
+        stdout_buffer_write(message.encode('utf8'))
     else:
         with open(args.tsv, 'w') as file_:
             file_.write(message)

--- a/brotab/main.py
+++ b/brotab/main.py
@@ -61,6 +61,7 @@ from urllib.parse import quote_plus, quote
 from brotab.inout import is_port_accepting_connections
 from brotab.inout import read_stdin
 from brotab.inout import get_mediator_ports
+from brotab.inout import in_temp_dir
 from brotab.utils import split_tab_ids, get_file_size, encode_query
 from brotab.search.query import query
 from brotab.search.index import index
@@ -75,7 +76,7 @@ from brotab.const import \
 FORMAT = '%(asctime)-15s %(levelname)-10s %(message)s'
 logging.basicConfig(
     format=FORMAT,
-    filename='/tmp/brotab.log',
+    filename=in_temp_dir('brotab.log'),
     level=logging.DEBUG)
 logger = logging.getLogger('brotab')
 logger.info('Logger has been created')
@@ -191,7 +192,7 @@ def query_tabs(args):
 
 def index_tabs(args):
     if args.tsv is None:
-        args.tsv = '/tmp/tabs.tsv'
+        args.tsv = in_temp_dir('tabs.tsv')
         args.cleanup = True
         logger.info(
             'index_tabs: retrieving tabs from browser into file %s', args.tsv)
@@ -425,7 +426,7 @@ def parse_args(args):
         Search across your indexed tabs using sqlite fts5 plugin.
         ''')
     parser_search_tabs.set_defaults(func=search_tabs)
-    parser_search_tabs.add_argument('--sqlite', type=str, default='/tmp/tabs.sqlite',
+    parser_search_tabs.add_argument('--sqlite', type=str, default=in_temp_dir('tabs.sqlite'),
                                     help='sqlite DB filename')
     parser_search_tabs.add_argument('query', type=str, help='Search query')
 
@@ -496,7 +497,7 @@ def parse_args(args):
         Index the text from browser's tabs. Text is put into sqlite fts5 table.
         ''')
     parser_index_tabs.set_defaults(func=index_tabs)
-    parser_index_tabs.add_argument('--sqlite', type=str, default='/tmp/tabs.sqlite',
+    parser_index_tabs.add_argument('--sqlite', type=str, default=in_temp_dir('tabs.sqlite'),
                                    help='sqlite DB filename')
     parser_index_tabs.add_argument('--tsv', type=str, default=None,
                                    help='get text from tabs and index the results')

--- a/brotab/main.py
+++ b/brotab/main.py
@@ -252,6 +252,8 @@ def get_text(args):
     logger.info('Get text from tabs')
     api = MultipleMediatorsAPI(create_clients(args.target_hosts))
     tabs = api.get_text([], args.delimiter_regex, args.replace_with)
+    re_match_tabs = re.compile('|'.join(['^%s\t' % tab for tab in args.tab_ids]))
+    tabs = [tab for tab in tabs if re_match_tabs.match(tab)]
 
     if args.cleanup:
         pattern = re.compile(r'\s+')
@@ -565,6 +567,8 @@ def parse_args(args):
         show text form all tabs
         ''')
     parser_get_text.set_defaults(func=get_text)
+    parser_get_text.add_argument('tab_ids', type=str, nargs='*',
+                                  help='Tab IDs to get text from')
     parser_get_text.add_argument('--tsv', type=str, default=None,
                                  help='tsv file to save results to')
     parser_get_text.add_argument('--cleanup', action='store_true',

--- a/brotab/mediator/brotab_mediator.py
+++ b/brotab/mediator/brotab_mediator.py
@@ -157,9 +157,9 @@ class BrowserRemoteAPI:
         self._transport.send(command)
         return self._transport.recv()
 
-    def activate_tab(self, tab_id):
+    def activate_tab(self, tab_id: int, focused: bool):
         logger.info('activating tab id: %s', tab_id)
-        command = {'name': 'activate_tab', 'tab_id': tab_id}
+        command = {'name': 'activate_tab', 'tab_id': tab_id, 'focused': focused}
         self._transport.send(command)
 
     def activateFocus_tab(self, tab_id):
@@ -259,7 +259,8 @@ def new_tab(query):
 
 @app.route('/activate_tab/<int:tab_id>')
 def activate_tab(tab_id):
-    browser.activate_tab(tab_id)
+    focused = bool(request.args.get('focused', False))
+    browser.activate_tab(tab_id, focused)
     return 'OK'
 
 @app.route('/activateFocus_tab/<int:tab_id>')

--- a/brotab/mediator/brotab_mediator.py
+++ b/brotab/mediator/brotab_mediator.py
@@ -374,7 +374,6 @@ def run_mediator(port: int, remote_api, no_logging=False):
 
 
 def main():
-    #signal.signal(signal.SIGPIPE, signal_pipe)
     monkeypatch_socket_bind()
     disable_click_echo()
 
@@ -393,7 +392,7 @@ def main():
         except OSError as e:
             logger.info('Cannot bind on port %s: %s', port, e)
         except BrokenPipeError:
-            signal_pipe
+            signal_pipe(e)
 
     else:
         logger.error('No TCP ports available for bind in range %s', port_range)

--- a/brotab/mediator/brotab_mediator.py
+++ b/brotab/mediator/brotab_mediator.py
@@ -18,6 +18,7 @@ from flask import request
 from brotab.utils import encode_query, decode_query
 from brotab.inout import get_mediator_ports
 from brotab.inout import is_port_accepting_connections
+from brotab.inout import in_temp_dir
 from brotab.const import \
     DEFAULT_GET_WORDS_MATCH_REGEX, \
     DEFAULT_GET_WORDS_JOIN_WITH, \
@@ -28,7 +29,7 @@ app = flask.Flask(__name__)
 
 FORMAT = '%(asctime)-15s %(process)-5d %(levelname)-10s %(message)s'
 MAX_LOG_SIZE = 50 * 1024 * 1024
-LOG_FILENAME = '/tmp/brotab_mediator.log'
+LOG_FILENAME = in_temp_dir('brotab_mediator.log')
 LOG_BACKUP_COUNT = 1
 
 logger = logging.getLogger('brotab_mediator')

--- a/brotab/mediator/brotab_mediator.py
+++ b/brotab/mediator/brotab_mediator.py
@@ -17,6 +17,7 @@ from flask import request
 
 from brotab.utils import encode_query, decode_query
 from brotab.inout import get_mediator_ports
+from brotab.inout import is_port_accepting_connections
 from brotab.const import \
     DEFAULT_GET_WORDS_MATCH_REGEX, \
     DEFAULT_GET_WORDS_JOIN_WITH, \
@@ -50,13 +51,6 @@ DEFAULT_GET_WORDS_MATCH_REGEX = encode_query(DEFAULT_GET_WORDS_MATCH_REGEX)
 DEFAULT_GET_WORDS_JOIN_WITH = encode_query(DEFAULT_GET_WORDS_JOIN_WITH)
 DEFAULT_GET_TEXT_DELIMITER_REGEX = encode_query(DEFAULT_GET_TEXT_DELIMITER_REGEX)
 DEFAULT_GET_TEXT_REPLACE_WITH = encode_query(DEFAULT_GET_TEXT_REPLACE_WITH)
-
-def is_port_accepting_connections(port):
-    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    s.settimeout(0.100)
-    result = s.connect_ex(('127.0.0.1', port))
-    s.close()
-    return result == 0
 
 
 def create_browser_remote_api(transport=None):

--- a/brotab/mediator/brotab_mediator.py
+++ b/brotab/mediator/brotab_mediator.py
@@ -162,13 +162,6 @@ class BrowserRemoteAPI:
         command = {'name': 'activate_tab', 'tab_id': tab_id, 'focused': focused}
         self._transport.send(command)
 
-    def activateFocus_tab(self, tab_id):
-        logger.info('activating tab id: %s', tab_id)
-        #win_id, tab_id = wintab_id.split(',')
-        command = {'name': 'activateFocus_tab', 'tab_id': tab_id}
-        self._transport.send(command)
-
-
     def get_active_tabs(self) -> str:
         logger.info('getting active tabs')
         command = {'name': 'get_active_tabs'}
@@ -261,11 +254,6 @@ def new_tab(query):
 def activate_tab(tab_id):
     focused = bool(request.args.get('focused', False))
     browser.activate_tab(tab_id, focused)
-    return 'OK'
-
-@app.route('/activateFocus_tab/<int:tab_id>')
-def activateFocus_tab(tab_id):
-    browser.activateFocus_tab(tab_id)
     return 'OK'
 
 

--- a/brotab/mediator/brotab_mediator.py
+++ b/brotab/mediator/brotab_mediator.py
@@ -380,6 +380,8 @@ def run_mediator(port: int, remote_api, no_logging=False):
         log.setLevel(logging.ERROR)
         log.disabled = True
         app.logger.disabled = True
+        from flask.logging import default_handler
+        app.logger.removeHandler(default_handler)
     return app.run(DEFAULT_HTTP_IFACE, port, debug=False, threaded=False)
 
 

--- a/brotab/platform.py
+++ b/brotab/platform.py
@@ -1,0 +1,11 @@
+import os
+import platform
+
+
+def get_editor() -> str:
+    mapping = {
+        'Windows': 'notepad'
+    }
+    system = platform.system()
+    editor = mapping.get(system, 'nvim')
+    return os.environ.get('EDITOR', editor)

--- a/brotab/platform.py
+++ b/brotab/platform.py
@@ -1,5 +1,43 @@
 import os
+import logging
 import platform
+
+
+logger = logging.getLogger('brotab')
+
+
+def make_windows_path(path):
+    return path.replace('/', os.sep)
+
+
+def make_windows_path_double_sep(path):
+    return path.replace('/', os.sep * 2).replace('\\', os.sep * 2)
+
+
+def windows_registry_set_key(key_path, value):
+    from winreg import CreateKey, SetValue, HKEY_CURRENT_USER, REG_SZ
+    with CreateKey(HKEY_CURRENT_USER, key_path) as sub_key:
+        SetValue(sub_key, None, REG_SZ, value)
+
+
+def register_native_manifest_windows_chrome(manifest_filename):
+    key_path = r'Software\Google\Chrome\NativeMessagingHosts\brotab_mediator'
+    manifest_filename = make_windows_path(manifest_filename)
+    logger.info('Setting registry key "%s" to "%s"', key_path, manifest_filename)
+    print('Setting registry key "%s" to "%s"' % (key_path, manifest_filename))
+    windows_registry_set_key(key_path, manifest_filename)
+
+
+def register_native_manifest_windows_firefox(manifest_filename):
+    key_path = r'Software\Mozilla\NativeMessagingHosts\brotab_mediator'
+    manifest_filename = make_windows_path(manifest_filename)
+    logger.info('Setting registry key "%s" to "%s"', key_path, manifest_filename)
+    print('Setting registry key "%s" to "%s"' % (key_path, manifest_filename))
+    windows_registry_set_key(key_path, manifest_filename)
+
+
+def is_windows() -> bool:
+    return platform.system() == 'Windows'
 
 
 def get_editor() -> str:

--- a/brotab/tests/mocks.py
+++ b/brotab/tests/mocks.py
@@ -1,0 +1,5 @@
+
+
+
+class BrowserPortMock:
+    pass

--- a/brotab/tests/test_inout.py
+++ b/brotab/tests/test_inout.py
@@ -1,0 +1,31 @@
+from unittest import TestCase
+from unittest.mock import patch
+
+from brotab.inout import edit_tabs_in_editor
+
+
+class TestEditor(TestCase):
+    @patch('brotab.inout.run_editor')
+    @patch('platform.system', side_effect=['Linux'])
+    @patch('os.environ', new={})
+    def test_run_editor_linux(self, _system_mock, _run_editor_mock):
+        assert ['1'] == edit_tabs_in_editor(['1'])
+        editor, _filename = _run_editor_mock.call_args[0]
+        assert editor == 'nvim'
+
+    @patch('brotab.inout.run_editor')
+    @patch('platform.system', side_effect=['Windows'])
+    @patch('os.environ', new={})
+    def test_run_editor_windows(self, _system_mock, _run_editor_mock):
+        assert ['1'] == edit_tabs_in_editor(['1'])
+        editor, _filename = _run_editor_mock.call_args[0]
+        assert editor == 'notepad'
+
+    @patch('brotab.inout.run_editor')
+    @patch('platform.system', side_effect=['Windows'])
+    @patch('os.environ', new={'EDITOR': 'custom'})
+    def test_run_editor_windows_custom(self, _system_mock, _run_editor_mock):
+        assert ['1'] == edit_tabs_in_editor(['1'])
+        editor, _filename = _run_editor_mock.call_args[0]
+        assert editor == 'custom'
+

--- a/brotab/tests/test_inout.py
+++ b/brotab/tests/test_inout.py
@@ -1,3 +1,4 @@
+import os
 from unittest import TestCase
 from unittest.mock import patch
 
@@ -10,22 +11,24 @@ class TestEditor(TestCase):
     @patch('os.environ', new={})
     def test_run_editor_linux(self, _system_mock, _run_editor_mock):
         assert ['1'] == edit_tabs_in_editor(['1'])
-        editor, _filename = _run_editor_mock.call_args[0]
+        editor, filename = _run_editor_mock.call_args[0]
         assert editor == 'nvim'
+        assert not os.path.exists(filename)
 
     @patch('brotab.inout.run_editor')
     @patch('platform.system', side_effect=['Windows'])
     @patch('os.environ', new={})
     def test_run_editor_windows(self, _system_mock, _run_editor_mock):
         assert ['1'] == edit_tabs_in_editor(['1'])
-        editor, _filename = _run_editor_mock.call_args[0]
+        editor, filename = _run_editor_mock.call_args[0]
         assert editor == 'notepad'
+        assert not os.path.exists(filename)
 
     @patch('brotab.inout.run_editor')
     @patch('platform.system', side_effect=['Windows'])
     @patch('os.environ', new={'EDITOR': 'custom'})
     def test_run_editor_windows_custom(self, _system_mock, _run_editor_mock):
         assert ['1'] == edit_tabs_in_editor(['1'])
-        editor, _filename = _run_editor_mock.call_args[0]
+        editor, filename = _run_editor_mock.call_args[0]
         assert editor == 'custom'
-
+        assert not os.path.exists(filename)

--- a/brotab/tests/test_integration.py
+++ b/brotab/tests/test_integration.py
@@ -140,7 +140,7 @@ class Chromium(Browser):
     PROFILE = 'chromium'
 
 
-# @pytest.mark.skip
+@pytest.mark.skip
 class TestChromium(TestCase):
     def setUp(self):
         self._echo_server = EchoServer()

--- a/brotab/tests/test_main.py
+++ b/brotab/tests/test_main.py
@@ -123,3 +123,22 @@ class TestText(WithMediator):
             {'delimiter_regex': '/\\n|\\r|\\t/g', 'name': 'get_text', 'replace_with': '" "'},
         ]
         assert output == [b'a.1.1\ttitle\turl\tbody\n']
+
+    def test_text_with_tab_id_ok(self):
+        self.mediator.transport.received.extend([
+            'mocked',
+            [
+                '1.1\ttitle\turl\tbody',
+                '1.2\ttitle\turl\tbody',
+                '1.3\ttitle\turl\tbody',
+            ],
+        ])
+
+        output = []
+        with patch('brotab.main.stdout_buffer_write', output.append):
+            self._run_commands(['text', 'a.1.2', 'a.1.3'])
+        assert self.mediator.transport.sent == [
+            {'name': 'get_browser'},
+            {'delimiter_regex': '/\\n|\\r|\\t/g', 'name': 'get_text', 'replace_with': '" "'},
+        ]
+        assert output == [b'a.1.2\ttitle\turl\tbody\na.1.3\ttitle\turl\tbody\n']

--- a/brotab/tests/test_main.py
+++ b/brotab/tests/test_main.py
@@ -106,3 +106,20 @@ class TestActivate(WithMediator):
             {'name': 'get_browser'},
             {'name': 'activate_tab', 'tab_id': 2, 'focused': True}
         ]
+
+
+class TestText(WithMediator):
+    def test_text_no_arguments_ok(self):
+        self.mediator.transport.received.extend([
+            'mocked',
+            ['1.1\ttitle\turl\tbody'],
+        ])
+
+        output = []
+        with patch('brotab.main.stdout_buffer_write', output.append):
+            self._run_commands(['text'])
+        assert self.mediator.transport.sent == [
+            {'name': 'get_browser'},
+            {'delimiter_regex': '/\\n|\\r|\\t/g', 'name': 'get_text', 'replace_with': '" "'},
+        ]
+        assert output == [b'a.1.1\ttitle\turl\tbody\n']

--- a/brotab/tests/test_main.py
+++ b/brotab/tests/test_main.py
@@ -1,0 +1,63 @@
+from unittest import TestCase
+from unittest.mock import patch
+from threading import Thread
+
+from brotab.main import run_commands
+from brotab.inout import get_free_tcp_port
+from brotab.api import SingleMediatorAPI
+from brotab.mediator.brotab_mediator import run_mediator
+from brotab.mediator.brotab_mediator import create_browser_remote_api
+
+
+class MockedLoggingTransport:
+    def __init__(self):
+        self.reset()
+    def reset(self):
+        self.sent = []
+        self.received = []
+    def send(self, message):
+        self.sent.append(message)
+    def recv(self):
+        if self.received:
+            result = self.received[0]
+            self.received = self.received[1:]
+            return result
+
+
+def _run_mediator_in_thread(port, transport) -> Thread:
+    remote_api = create_browser_remote_api(transport)
+    thread = Thread(target=lambda: run_mediator(port, remote_api, no_logging=True))
+    thread.daemon = True
+    thread.start()
+    return thread
+
+
+class MockedMediator:
+    def __init__(self, prefix='a'):
+        self.port = get_free_tcp_port()
+        self.transport = MockedLoggingTransport()
+        self.transport.received = ['mocked']
+        self.thread = _run_mediator_in_thread(self.port, self.transport)
+        self.api = SingleMediatorAPI(prefix, port=self.port, startup_timeout=1)
+        assert self.api._browser == 'mocked'
+        self.transport.reset()
+    def shutdown_and_wait(self):
+        self.api.shutdown()
+        self.thread.join()
+    def __enter__(self):
+        return self
+    def __exit__(self, type_, value, tb):
+        self.shutdown_and_wait()
+
+
+class TestActivate(TestCase):
+    @patch('brotab.main.get_mediator_ports')
+    def test_activate_ok(self, get_mediator_ports_mock):
+        with MockedMediator('a') as mediator:
+            get_mediator_ports_mock.side_effect = \
+                [range(mediator.port, mediator.port + 1)]
+            run_commands(['activate', 'a.1.2'])
+            assert mediator.transport.sent == [
+                {'name': 'get_browser'},
+                {'name': 'activate_tab', 'tab_id': 2}
+            ]

--- a/brotab/tests/test_main.py
+++ b/brotab/tests/test_main.py
@@ -52,10 +52,10 @@ class MockedMediator:
 
 
 def _run_commands(commands):
-        with MockedMediator('a') as mediator:
-            get_mediator_ports_mock.side_effect = \
-                [range(mediator.port, mediator.port + 1)]
-            run_commands(commands)
+    with MockedMediator('a') as mediator:
+        get_mediator_ports_mock.side_effect = \
+            [range(mediator.port, mediator.port + 1)]
+        run_commands(commands)
 
 
 class WithMediator(TestCase):

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,4 +1,5 @@
 flask
 requests
 pytest
+pytest-cov
 psutil

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,3 @@
 flask
 requests
-pytest
-pytest-cov
 psutil

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,4 +1,4 @@
--r base.txt
+-r test.txt
 
 ipython
 ipdb

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,0 +1,4 @@
+-r base.txt
+
+pytest
+pytest-cov

--- a/setup.py
+++ b/setup.py
@@ -96,7 +96,9 @@ class UploadCommand(Command):
 packages = find_packages(
     # where='brotab',
     # exclude=('brotab.tests', 'firefox_extension', 'firefox_mediator')
-    exclude=('tests', 'firefox_extension', 'firefox_mediator')
+    #exclude=('tests', 'firefox_extension', 'firefox_mediator')
+    include=('brotab', 'brotab.tests'),
+    exclude=('firefox_extension', 'firefox_mediator')
 )
 print('>>', packages)
 
@@ -139,15 +141,12 @@ setup(
         # Full list: https://pypi.python.org/pypi?%3Aaction=list_classifiers
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2.6',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: Implementation :: CPython',
-        'Programming Language :: Python :: Implementation :: PyPy'
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: Implementation :: CPython'
     ],
     # $ setup.py publish support.
     cmdclass={


### PR DESCRIPTION
* add "--target" argument to disable automatic mediator discovery and be
  able to specify mediator's host:port address. Multiple entries are
  separated with a comma, e.g. --target "localhost:2000,127.0.0.1:3000"
* add "--focused" argument to "activate" tab command. This will bring browser
  into focus
* automatically register native app manifest in the Windows Registry when doing
  "bt install" (Windows only)
* detect user's temporary directory (Windows-related fix)
* use "notepad" editor for "bt move" command on Windows
* add optional tab_ids filter to "bt text [tab_id]" command