### PR TITLE
fix typo: 'form' → 'from'

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ positional arguments:
     words               show sorted unique words from all active tabs of all
                         clients. This is a helper for webcomplete deoplete plugin
                         that helps complete words from the browser
-    text                show text form all tabs
-    html                show html form all tabs
+    text                show text from all tabs
+    html                show html from all tabs
     dup                 display reminder on how to show duplicate tabs using
                         command-line tools
     windows             display available prefixes and window IDs, along with the

--- a/brotab/main.py
+++ b/brotab/main.py
@@ -576,7 +576,7 @@ def parse_args(args):
     parser_get_text = subparsers.add_parser(
         'text',
         help='''
-        show text form all tabs
+        show text from all tabs
         ''')
     parser_get_text.set_defaults(func=get_text)
     parser_get_text.add_argument('tab_ids', type=str, nargs='*',
@@ -596,7 +596,7 @@ def parse_args(args):
     parser_get_html = subparsers.add_parser(
         'html',
         help='''
-        show html form all tabs
+        show html from all tabs
         ''')
     parser_get_html.set_defaults(func=get_html)
     parser_get_html.add_argument('tab_ids', type=str, nargs='*',


### PR DESCRIPTION
```
text                show text form all tabs
html                show html form all tabs
```

I believe it should be 'from' instead of 'form'.