### PR TITLE
Correct command of Installation via pipx

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Features to show:
 
 1. Install command-line client:
 ```
-$ pipx brotab                # preferred method
+$ pipx install brotab        # preferred method, if pipx not installed: $ sudo apt install pipx
 $ pip install --user brotab  # alternative
 $ sudo pip install brotab    # alternative
 ```


### PR DESCRIPTION
## Problem
There was a little mistake in the command that was written to install brotab using pipx.

## Solution
It was written `pipx brotab` but the command that works is `pipx install brotab`. 
Also, in my ubuntu desktop, pipx wasn't installed, so I need to install it via the command 'sudo apt install pipx'.  This worked for me, so I thought to correct this mistake in the README to avoid any confusion in people using it in future.