### PR TITLE
Extension option for adding an instanceIdentifier

### DIFF
--- a/brotab/extension/background.js
+++ b/brotab/extension/background.js
@@ -192,7 +192,12 @@ class ChromeTabs extends BrowserTabs {
   }
 
   getBrowserName() {
-      return "chrome/chromium";
+      chrome.storage.sync.get({
+          instanceIdentifier: '[none]'
+        }, function(items) {
+          instanceIdentifier = items.instanceIdentifier;
+      });
+      return "chrome/chromium\t"+instanceIdentifier;
   }
 }
 
@@ -201,6 +206,7 @@ console.log("Detecting browser");
 var port = undefined;
 var tabs = undefined;
 var browserTabs = undefined;
+var instanceIdentifier = undefined;
 const NATIVE_APP_NAME = 'brotab_mediator';
 reconnect();
 

--- a/brotab/extension/chrome/background.js
+++ b/brotab/extension/chrome/background.js
@@ -192,7 +192,12 @@ class ChromeTabs extends BrowserTabs {
   }
 
   getBrowserName() {
-      return "chrome/chromium";
+      chrome.storage.sync.get({
+          instanceIdentifier: '[none]'
+        }, function(items) {
+          instanceIdentifier = items.instanceIdentifier;
+      });
+      return "chrome/chromium\t"+instanceIdentifier;
   }
 }
 
@@ -201,6 +206,7 @@ console.log("Detecting browser");
 var port = undefined;
 var tabs = undefined;
 var browserTabs = undefined;
+var instanceIdentifier = undefined;
 const NATIVE_APP_NAME = 'brotab_mediator';
 reconnect();
 

--- a/brotab/extension/chrome/manifest.json
+++ b/brotab/extension/chrome/manifest.json
@@ -8,9 +8,10 @@
   "background": {
     "scripts": ["background.js"]
   },
+  "options_page": "options.html",
   "icons": {
       "128": "brotab-icon-128x128.png"
   },
-  "permissions": ["nativeMessaging", "tabs", "activeTab", "<all_urls>"],
+  "permissions": ["nativeMessaging", "tabs", "activeTab", "<all_urls>", "storage"],
   "short_name": "BroTab"
 }

--- a/brotab/extension/chrome/options.html
+++ b/brotab/extension/chrome/options.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head><title>My Test Extension Options</title></head>
+<body>
+
+<select id="instanceIdentifier">
+ <option value="[none]">[none]</option>
+  <option value="chrome1">chrome1</option>
+ <option value="chrome2">chrome2</option>
+</select>
+
+<div id="status"></div>
+<button id="save">Save</button>
+
+<script src="options.js"></script>
+</body>
+</html>

--- a/brotab/extension/chrome/options.js
+++ b/brotab/extension/chrome/options.js
@@ -1,0 +1,28 @@
+// Saves options to chrome.storage
+function save_options() {
+  var instanceIdentifier = document.getElementById('instanceIdentifier').value;
+  chrome.storage.sync.set({
+    instanceIdentifier: instanceIdentifier
+  }, function() {
+    // Update status to let user know options were saved.
+    var status = document.getElementById('status');
+    status.textContent = 'Options saved.';
+    setTimeout(function() {
+      status.textContent = '';
+    }, 750);
+  });
+}
+
+// Restores select box using the preferences
+// stored in chrome.storage.
+function restore_options() {
+  // Use default value color = 'red' and likesColor = true.
+  chrome.storage.sync.get({
+    instanceIdentifier: '[none]'
+  }, function(items) {
+    document.getElementById('instanceIdentifier').value = items.instanceIdentifier;
+  });
+}
+document.addEventListener('DOMContentLoaded', restore_options);
+document.getElementById('save').addEventListener('click',
+    save_options);

--- a/brotab/extension/firefox/background.js
+++ b/brotab/extension/firefox/background.js
@@ -192,7 +192,12 @@ class ChromeTabs extends BrowserTabs {
   }
 
   getBrowserName() {
-      return "chrome/chromium";
+      chrome.storage.sync.get({
+          instanceIdentifier: '[none]'
+        }, function(items) {
+          instanceIdentifier = items.instanceIdentifier;
+      });
+      return "chrome/chromium\t"+instanceIdentifier;
   }
 }
 
@@ -201,6 +206,7 @@ console.log("Detecting browser");
 var port = undefined;
 var tabs = undefined;
 var browserTabs = undefined;
+var instanceIdentifier = undefined;
 const NATIVE_APP_NAME = 'brotab_mediator';
 reconnect();
 

--- a/brotab/extension/firefox/manifest.json
+++ b/brotab/extension/firefox/manifest.json
@@ -6,10 +6,11 @@
   "background": {
     "scripts": ["background.js"]
   },
+  "options_page": "options.html",
   "icons": {
       "128": "brotab-icon-128x128.png"
   },
-  "permissions": ["nativeMessaging", "tabs", "activeTab", "<all_urls>"],
+  "permissions": ["nativeMessaging", "tabs", "activeTab", "<all_urls>", "storage"],
   "applications": {
     "gecko": {
       "id": "brotab_mediator@example.org",

--- a/brotab/extension/firefox/options.html
+++ b/brotab/extension/firefox/options.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head><title>My Test Extension Options</title></head>
+<body>
+
+<select id="instanceIdentifier">
+ <option value="[none]">[none]</option>
+  <option value="chrome1">chrome1</option>
+ <option value="chrome2">chrome2</option>
+</select>
+
+<div id="status"></div>
+<button id="save">Save</button>
+
+<script src="options.js"></script>
+</body>
+</html>

--- a/brotab/extension/firefox/options.js
+++ b/brotab/extension/firefox/options.js
@@ -1,0 +1,28 @@
+// Saves options to chrome.storage
+function save_options() {
+  var instanceIdentifier = document.getElementById('instanceIdentifier').value;
+  chrome.storage.sync.set({
+    instanceIdentifier: instanceIdentifier
+  }, function() {
+    // Update status to let user know options were saved.
+    var status = document.getElementById('status');
+    status.textContent = 'Options saved.';
+    setTimeout(function() {
+      status.textContent = '';
+    }, 750);
+  });
+}
+
+// Restores select box using the preferences
+// stored in chrome.storage.
+function restore_options() {
+  // Use default value color = 'red' and likesColor = true.
+  chrome.storage.sync.get({
+    instanceIdentifier: '[none]'
+  }, function(items) {
+    document.getElementById('instanceIdentifier').value = items.instanceIdentifier;
+  });
+}
+document.addEventListener('DOMContentLoaded', restore_options);
+document.getElementById('save').addEventListener('click',
+    save_options);


### PR DESCRIPTION
**Initial PR for discussion**

Adding an option to the extension so that an instanceIdentifier can be added, which is the available via `bt clients`. The allows bt to distinguish between different 'instances of the extension', such as chrome running different profiles (which will have the extension added separately, with different instanceIdentifier).

Addresses [#71](https://github.com/balta2ar/brotab/issues/71)

Note: 
- Options page is basic
- Not tested on firefox
