### PR TITLE
clean up unused pip import in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,6 @@ import sys
 from shutil import rmtree
 
 from setuptools import find_packages, setup, Command
-import pip
 
 # Save ~200ms on script startup time
 # See https://github.com/ninjaaron/fast-entry_points


### PR DESCRIPTION
Since https://github.com/balta2ar/brotab/commit/930a443961e60c2a5a38efb5082a4138bb545f59, `pip` is no longer used in setup.py and can be removed.