### PR TITLE
New features: screenshot, open URLs in new window, query for +windowFocused

### DIFF
--- a/brotab/api.py
+++ b/brotab/api.py
@@ -162,6 +162,9 @@ class SingleMediatorAPI(object):
     def get_active_tabs(self, args) -> List[str]:
         return [self.prefix_tab(tab) for tab in self._get('/get_active_tabs').split(',')]
 
+    def get_screenshot(self, args):
+        return self._get('/get_screenshot')
+
     def query_tabs(self, args):
         query = args
         if isinstance(query, str):

--- a/brotab/extension/chrome/background.js
+++ b/brotab/extension/chrome/background.js
@@ -50,6 +50,10 @@ class BrowserTabs {
     throw new Error('getActive is not implemented');
   }
 
+  getActiveScreenshot(onSuccess) {
+    throw new Error('getActiveScreenshot is not implemented');
+  }
+
   runScript(tab_id, script, payload, onSuccess, onError) {
     throw new Error('runScript is not implemented');
   }
@@ -109,6 +113,29 @@ class FirefoxTabs extends BrowserTabs {
   getActive(onSuccess) {
     this._browser.tabs.query({active: true}).then(
       onSuccess,
+      (error) => console.log(`Error: ${error}`)
+    );
+  }
+
+  getActiveScreenshot(onSuccess) {
+    let queryOptions = { active: true, lastFocusedWindow: true };
+    this._browser.tabs.query(queryOptions).then(
+      (tabs) => {
+        let tab = tabs[0];
+        let windowId = tab.windowId;
+        let tabId = tab.id;
+        this._browser.tabs.captureVisibleTab(windowId, { format: 'png' }).then(
+          function(data) {
+            const message = {
+              tab: tabId,
+              window: windowId,
+              data: data
+            };
+            onSuccess(message);
+          },
+          (error) => console.log(`Error: ${error}`)
+        );
+      },
       (error) => console.log(`Error: ${error}`)
     );
   }
@@ -174,6 +201,24 @@ class ChromeTabs extends BrowserTabs {
 
   getActive(onSuccess) {
     this._browser.tabs.query({active: true}, onSuccess);
+  }
+
+  getActiveScreenshot(onSuccess) {
+    // this._browser.tabs.captureVisibleTab(null, { format: 'png' }, onSuccess);
+    let queryOptions = { active: true, lastFocusedWindow: true };
+    this._browser.tabs.query(queryOptions, (tabs) => {
+      let tab = tabs[0];
+      let windowId = tab.windowId;
+      let tabId = tab.id;
+      this._browser.tabs.captureVisibleTab(windowId, { format: 'png' }, function(data) {
+        const message = {
+          tab: tabId,
+          window: windowId,
+          data: data
+        };
+        onSuccess(message);
+      });
+    });
   }
 
   runScript(tab_id, script, payload, onSuccess, onError) {
@@ -405,6 +450,12 @@ function getActiveTabs() {
   });
 }
 
+function getActiveScreenshot() {
+  browserTabs.getActiveScreenshot(data => {
+    port.postMessage(data);
+  });
+}
+
 function getWordsScript(match_regex, join_with) {
   return GET_WORDS_SCRIPT
     .replace('#match_regex#', match_regex)
@@ -607,6 +658,11 @@ port.onMessage.addListener((command) => {
   else if (command['name'] == 'get_active_tabs') {
     console.log('Getting active tabs');
     getActiveTabs();
+  }
+
+  else if (command['name'] == 'get_screenshot') {
+    console.log('Getting visible screenshot');
+    getActiveScreenshot();
   }
 
   else if (command['name'] == 'get_words') {

--- a/brotab/main.py
+++ b/brotab/main.py
@@ -54,7 +54,7 @@ import time
 from argparse import ArgumentParser
 from functools import partial
 from itertools import groupby
-from json import loads
+from json import loads, dumps
 from string import ascii_lowercase
 from typing import List
 from typing import Tuple
@@ -172,6 +172,17 @@ def show_active_tabs(args):
         for tab in tabs:
             print('%s\t%s' % (tab, api))
 
+
+def screenshot(args):
+    brotab_logger.info('Getting screenshot: %s', args)
+    apis = create_clients(args.target_hosts)
+    for api in apis:
+        result = api.get_screenshot(args)
+        # print(result, api)
+        result = loads(result)
+        result['api'] = api._prefix[:1]
+        result = dumps(result)
+        print(result)
 
 def search_tabs(args):
     for result in query(args.sqlite, args.query):
@@ -484,6 +495,13 @@ def parse_args(args):
         "<prefix>.<window_id>.<tab_id>"
         ''')
     parser_active_tab.set_defaults(func=show_active_tabs)
+
+    parser_screenshot = subparsers.add_parser(
+        'screenshot',
+        help='''
+        return base64 screenshot in json object with keys: 'data' (base64 png), 'tab' (tab id of visible tab), 'window' (window id of visible tab), 'api' (prefix of client api)
+        ''')
+    parser_screenshot.set_defaults(func=screenshot)
 
     parser_search_tabs = subparsers.add_parser(
         'search',

--- a/brotab/main.py
+++ b/brotab/main.py
@@ -612,7 +612,7 @@ def parse_args(args):
         open URLs from the stdin (one URL per line). One positional argument is
         required: <prefix>.<window_id> OR <client>. If window_id is not
         specified, URL will be opened in the active window of the specifed
-        client
+        client. If window_id is 0, URLs will be opened in new window.
         ''')
     parser_open_urls.set_defaults(func=open_urls)
     parser_open_urls.add_argument(

--- a/brotab/main.py
+++ b/brotab/main.py
@@ -554,6 +554,10 @@ def parse_args(args):
                                    help='tabs are in the last focused window.')
     parser_query_tabs.add_argument('-lastFocusedWindow', action='store_const', const=False, default=None,
                                    help='tabs are not in the last focused window.')
+    parser_query_tabs.add_argument('+windowFocused', action='store_const', const=True, default=None,
+                                   help='tabs are in the focused window.')
+    parser_query_tabs.add_argument('-windowFocused', action='store_const', const=False, default=None,
+                                   help='tabs are not in the focused window.')
     parser_query_tabs.add_argument('-status', type=str, choices=['loading', 'complete'],
                                    help='whether the tabs have completed loading i.e. loading or complete.')
     parser_query_tabs.add_argument('-title', type=str,

--- a/brotab/mediator/http_server.py
+++ b/brotab/mediator/http_server.py
@@ -67,6 +67,7 @@ class MediatorHttpServer:
         self.app.route('/new_tab/<query>', methods=['GET'])(self.new_tab)
         self.app.route('/activate_tab/<int:tab_id>', methods=['GET'])(self.activate_tab)
         self.app.route('/get_active_tabs', methods=['GET'])(self.get_active_tabs)
+        self.app.route('/get_screenshot', methods=['GET'])(self.get_screenshot)
         self.app.route('/get_words/<string:tab_id>', methods=['GET'])(self.get_words)
         self.app.route('/get_words', methods=['GET'])(self.get_words)
         self.app.route('/get_text', methods=['GET'])(self.get_text)
@@ -140,6 +141,9 @@ class MediatorHttpServer:
 
     def get_active_tabs(self):
         return self.remote_api.get_active_tabs()
+
+    def get_screenshot(self):
+        return self.remote_api.get_screenshot()
 
     def get_words(self, tab_id=None):
         tab_id = int(tab_id) if is_valid_integer(tab_id) else None

--- a/brotab/mediator/remote_api.py
+++ b/brotab/mediator/remote_api.py
@@ -97,6 +97,12 @@ class BrowserRemoteAPI:
         self._transport.send(command)
         return self._transport.recv()
 
+    def get_screenshot(self) -> str:
+        mediator_logger.info('getting screemsjpt')
+        command = {'name': 'get_screenshot'}
+        self._transport.send(command)
+        return self._transport.recv()
+
     def get_words(self, tab_id: str, match_regex: str, join_with: str):
         mediator_logger.info('getting tab words: %s', tab_id)
         command = {

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,3 +1,4 @@
 Flask==2.0.2
 requests==2.24.0
 psutil==5.8.0
+Werkzeug==2.2.2


### PR DESCRIPTION
- Added `bt screenshot` to get a screenshot of the current visible tab. Also returns the api prefix, window id, and tab id with the base64 png data (#106)
- Modified `bt open` so if window_id is specified as "0", a new window will be opened. Multiple URLs provided to stdin will all be opened in the new window (#39)
- Added a query option for +windowFocused or -windowFocused to detect if the browser application is being used or not

also the first commit updates requirements.txt as a work-around for #105