### PR TITLE
add Werkzeug version constraint to requirements

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,3 +1,4 @@
-Flask==2.0.2
 requests==2.24.0
 psutil==5.8.0
+Flask==2.0.2
+Werkzeug<3.0


### PR DESCRIPTION
brotab's mediator failed to run for me on Ubuntu 20.04 due to the following error:
`ImportError: cannot import name 'url_quote' from 'werkzeug.urls' (/usr/local/lib/python3.8/dist-packages/werkzeug/urls.py)` in `mediator/brotab_mediator.py`.

This occurs with Werkzeug >= 3.0. Flask 2.0.2's should therefore specify Werkzeug < 3.0, but specifies only Werkzeug >= 2.0. Unless and until this is fixed upstream, clients of Flask 2.0.2 must specify Werkzeug < 3.0 themselves to avoid this error.