### PR TITLE
fix: bt update -openerTabId works again

### DIFF
--- a/brotab/api.py
+++ b/brotab/api.py
@@ -379,6 +379,7 @@ class MultipleMediatorsAPI(object):
             updates = [deepcopy(u) for u in all_updates if api.prefix_match(u['tab_id'])]
             for u in updates:
                 u['tab_id'] = int_tab_id(u['tab_id'])
+                u['properties']['openerTabId'] = int_tab_id(u['properties']['openerTabId'])
             results.extend(api.update_tabs(updates))
         return results
 


### PR DESCRIPTION
We need to parse a bt tab id like 'a.X.Y' or even just 'Y' from a string
into an int, otherwise we get the following type errors, respectively:

    Uncaught (in promise) Error: Type error for parameter updateProperties (Error processing openerTabId: Expected integer instead of "a.1.31") for tabs.update.

    Uncaught (in promise) Error: Type error for parameter updateProperties (Error processing openerTabId: Expected integer instead of "31") for tabs.update.
