### PR TITLE
Fix `bt move` causing 500 error

### DIFF
--- a/brotab/mediator/http_server.py
+++ b/brotab/mediator/http_server.py
@@ -59,7 +59,7 @@ class MediatorHttpServer:
         self.app.route('/shutdown', methods=['GET'])(self.shutdown)
         self.app.route('/list_tabs', methods=['GET'])(self.list_tabs)
         self.app.route('/query_tabs/<query_info>', methods=['GET'])(self.query_tabs)
-        self.app.route('/move_tabs/<query_info>', methods=['GET'])(self.move_tabs)
+        self.app.route('/move_tabs/<move_triplets>', methods=['GET'])(self.move_tabs)
         self.app.route('/open_urls/<int:window_id>', methods=['POST'])(self.open_urls)
         self.app.route('/update_tabs', methods=['POST'])(self.update_tabs)
         self.app.route('/open_urls', methods=['POST'])(self.open_urls)


### PR DESCRIPTION
Replaced the `/move_tabs/<query_info>` route with `/move_tabs/<move_triplets>` to match the `move_tabs` function signature.

Fixes the 500 error when using `bt move` (#119)