### PR TITLE
Fix HTTP port env handling and include max port

### DIFF
--- a/brotab/env.py
+++ b/brotab/env.py
@@ -17,11 +17,11 @@ def http_iface():
 
 
 def min_http_port():
-    return environ.get('MIN_HTTP_PORT', DEFAULT_MIN_HTTP_PORT)
+    return int(environ.get('MIN_HTTP_PORT', DEFAULT_MIN_HTTP_PORT))
 
 
 def max_http_port():
-    return environ.get('MAX_HTTP_PORT', DEFAULT_MAX_HTTP_PORT)
+    return int(environ.get('MAX_HTTP_PORT', DEFAULT_MAX_HTTP_PORT))
 
 
 def load_dotenv(filename=None):

--- a/brotab/inout.py
+++ b/brotab/inout.py
@@ -18,7 +18,7 @@ from brotab.platform import get_editor
 
 
 def get_mediator_ports() -> Iterable:
-    return range(min_http_port(), max_http_port())
+    return range(min_http_port(), max_http_port() + 1)
 
 
 def get_available_tcp_port(start=1025, end=65536, host='127.0.0.1'):


### PR DESCRIPTION
- Cast `MIN_HTTP_PORT` and `MAX_HTTP_PORT` environment variables to `int`, fixing a ValueError if these are ever defined.
- Fix off-by-one error in mediator port discovery by including the `MAX_HTTP_PORT` in the scan range.